### PR TITLE
chore: add federated learning use case placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository is collection of accelerated platform reference architectures an
 
 - [GKE AI/ML Platform for enabling AI/ML Ops](/docs/platforms/gke-aiml/README.md)
   - [Model Fine Tuning Pipeline](/docs/use-cases/model-fine-tuning-pipeline/README.md)
+  - [Federated learning](/docs/use-cases/federated-learning/README.md)
 
 ## Contributing
 

--- a/docs/use-cases/federated-learning/README.md
+++ b/docs/use-cases/federated-learning/README.md
@@ -1,0 +1,6 @@
+# Federated learning
+
+For more information about the federated learning use case, see:
+
+- [Cross-silo and cross-device federated learning on Google Cloud](https://cloud.google.com/architecture/cross-silo-cross-device-federated-learning-google-cloud)
+- [Federated learning on Google Cloud](/platforms/gke/base/use-cases/federated-learning/README.md)

--- a/platforms/gke/base/use-cases/federated-learning/README.md
+++ b/platforms/gke/base/use-cases/federated-learning/README.md
@@ -1,0 +1,1 @@
+# Federated learning on Google Cloud


### PR DESCRIPTION
Create docs and code placeholders for the federated learning use case:

- Reference in the main README
- Placeholder README in docs/use-cases
- Placeholder README in platforms/gke/base/use-cases

Starting with this PR in order to have smaller PRs to review in the future.

I'll refine both placeholders as we add components to the implementation.