### PR TITLE
[2] Configure firewall rules and policies for the federated learning use case

### DIFF
--- a/platforms/gke/base/_shared_config/cluster_variables.tf
+++ b/platforms/gke/base/_shared_config/cluster_variables.tf
@@ -33,6 +33,17 @@ locals {
 
   kubeconfig_directory = abspath("${path.module}/../kubeconfig")
   kubeconfig_file      = abspath("${local.kubeconfig_directory}/${var.cluster_project_id}-${local.unique_identifier_prefix}")
+
+  # Minimal roles for nodepool SA https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+  cluster_sa_roles = [
+    "roles/artifactregistry.reader",
+    "roles/autoscaling.metricsWriter",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/serviceusage.serviceUsageConsumer",
+    "roles/stackdriver.resourceMetadata.writer",
+  ]
 }
 
 variable "cluster_binary_authorization_evaluation_mode" {

--- a/platforms/gke/base/_shared_config/configmanagement_variables.tf
+++ b/platforms/gke/base/_shared_config/configmanagement_variables.tf
@@ -19,7 +19,8 @@ locals {
   git_creds_secret = var.configmanagement_git_credentials.secret_name == null ? "${var.platform_name}-git-creds" : var.configmanagement_git_credentials.secret_name
 
   oci_repo_id              = "${local.unique_identifier_prefix}-config-sync"
-  oci_repo_url             = "${var.cluster_region}-docker.pkg.dev/${data.google_project.cluster.project_id}/${local.oci_repo_id}"
+  oci_repo_domain          = "${var.cluster_region}-docker.pkg.dev"
+  oci_repo_url             = "${local.oci_repo_domain}/${data.google_project.cluster.project_id}/${local.oci_repo_id}"
   oci_root_sync_image      = "${local.oci_root_sync_image_name}:${local.oci_root_sync_image_tag}"
   oci_root_sync_image_name = "root-sync"
   oci_root_sync_image_tag  = "latest"

--- a/platforms/gke/base/core/container_cluster/service_account.tf
+++ b/platforms/gke/base/core/container_cluster/service_account.tf
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
-  # Minimal roles for nodepool SA https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
-  cluster_sa_roles = [
-    "roles/artifactregistry.reader",
-    "roles/autoscaling.metricsWriter",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer",
-    "roles/serviceusage.serviceUsageConsumer",
-    "roles/stackdriver.resourceMetadata.writer",
-  ]
-}
-
 # Create dedicated service account for the cluster nodes
 resource "google_service_account" "cluster" {
   for_each = toset(var.cluster_node_pool_default_service_account_id == null ? ["created"] : [])

--- a/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
+++ b/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
@@ -30,6 +30,7 @@ resource "google_gke_hub_feature_membership" "cluster_policycontroller" {
 
   policycontroller {
     policy_controller_hub_config {
+      audit_interval_seconds    = 60
       install_spec              = "INSTALL_SPEC_ENABLED"
       log_denies_enabled        = true
       mutation_enabled          = true

--- a/platforms/gke/base/use-cases/federated-learning/common.sh
+++ b/platforms/gke/base/use-cases/federated-learning/common.sh
@@ -42,8 +42,26 @@ federated_learning_core_platform_terraservices=(
 
 # shellcheck disable=SC2034 # Variable is used in other scripts
 federated_learning_terraservices=(
+  "firewall"
   "container_image_repository"
   "private_google_access"
+  "workload_identity"
+  "container_node_pool"
+  "config_management"
+)
+
+# shellcheck disable=SC2034 # Variable is used in other scripts
+core_platform_init_terraservices=(
+  "initialize"
+  "networking"
+)
+
+# shellcheck disable=SC2034 # Variable is used in other scripts
+core_platform_terraservices=(
+  "container_cluster"
+  "gke_enterprise/fleet_membership"
+  "gke_enterprise/configmanagement/oci"
+  "gke_enterprise/policycontroller"
 )
 
 # shellcheck disable=SC2034 # Variable is used in other scripts
@@ -68,7 +86,7 @@ apply_or_destroy_terraservice() {
 
   echo "Initializing ${terraservice} Terraform environment"
   cd "${FEDERATED_LEARNING_USE_CASE_TERRAFORM_DIR}/${terraservice}" &&
-    terraform init
+    terraform init -input=false
 
   echo "Current working directory: $(pwd)"
 
@@ -79,7 +97,9 @@ apply_or_destroy_terraservice() {
     _terraform_result=$?
   elif [[ "${operation_mode}" == "destroy" ]]; then
     echo "Destroying ${terraservice}"
-    terraform destroy -auto-approve
+    terraform destroy \
+      -auto-approve \
+      -input=false
     _terraform_result=$?
   else
     echo "Error: operation mode not supported: ${operation_mode}"

--- a/platforms/gke/base/use-cases/federated-learning/deploy.sh
+++ b/platforms/gke/base/use-cases/federated-learning/deploy.sh
@@ -23,13 +23,6 @@ source "${ACP_PLATFORM_BASE_DIR}/use-cases/federated-learning/common.sh"
 
 start_timestamp_federated_learning=$(date +%s)
 
-echo "Initializing the core platform"
-# Don't provision any core platform terraservice becuase we just need
-# to initialize the terraform environment and remote backend
-# shellcheck disable=SC1091
-CORE_TERRASERVICES_APPLY="initialize" \
-  "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
-
 echo "Preparing core platform configuration files"
 for configuration_variable in "${TERRAFORM_CLUSTER_CONFIGURATION[@]}"; do
   write_terraform_configuration_variable_to_file "${configuration_variable}" "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
@@ -37,6 +30,13 @@ done
 for configuration_variable in "${TERRAFORM_CORE_INITIALIZE_CONFIGURATION[@]}"; do
   write_terraform_configuration_variable_to_file "${configuration_variable}" "${ACP_PLATFORM_SHARED_CONFIG_INITIALIZE_AUTO_VARS_FILE}"
 done
+
+echo "Initializing the core platform"
+# Don't provision any core platform terraservice becuase we just need
+# to initialize the terraform environment and remote backend
+# shellcheck disable=SC1091,SC2154
+CORE_TERRASERVICES_APPLY="${core_platform_init_terraservices[*]}" \
+  "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
 
 echo "Provision services that the core platform depends on"
 # shellcheck disable=SC2154 # variable defined in common.sh
@@ -50,8 +50,8 @@ fi
 edit_terraform_configuration_variable_value_in_file "cluster_database_encryption_key_name_placeholder" "${cluster_database_encryption_key_id}" "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
 
 echo "Provisioning the core platform"
-# shellcheck disable=SC1091,SC2034 # Variable is used in other scripts
-CORE_TERRASERVICES_APPLY="networking container_cluster gke_enterprise/fleet_membership" \
+# shellcheck disable=SC1091,SC2034,SC2154 # Variable is used in other scripts
+CORE_TERRASERVICES_APPLY="${core_platform_terraservices[*]}" \
   "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
 
 echo "Provisioning the use case resources"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
@@ -16,21 +16,83 @@ locals {
   gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
   gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
 
-  tenants = {
+  # Define values that other values depend on
+  _tenants_initial = {
     for name in var.federated_learning_tenant_names : name => {
-      tenant_name                                 = name
-      tenant_nodepool_name                        = format("%s-%s-p", local.cluster_name, name)
-      tenant_nodepool_sa_name                     = format("%s-%s-n", local.cluster_name, name)
-      tenant_apps_sa_name                         = format("%s-%s-a", local.cluster_name, name)
-      tenant_apps_kubernetes_service_account_name = local.tenant_apps_kubernetes_service_account_name
+      tenant_name                                        = name
+      tenant_nodepool_name                               = format("%s-%s-p", local.cluster_name, name)
+      tenant_nodepool_sa_name                            = format("%s-%s-n", local.cluster_name, name)
+      tenant_apps_sa_name                                = format("%s-%s-a", local.cluster_name, name)
+      tenant_apps_kubernetes_service_account_name        = local.tenant_apps_kubernetes_service_account_name
+      tenant_apps_workload_identity_service_account_name = "serviceAccount:${var.cluster_project_id}.svc.id.goog[${name}/${local.tenant_apps_kubernetes_service_account_name}]"
     }
   }
+
+  # These values depend on tenants_initial values
+  _tenants_intermediate = {
+    for name, values in local._tenants_initial : name => {
+      tenant_name                                        = values.tenant_name
+      tenant_nodepool_name                               = values.tenant_nodepool_name
+      tenant_nodepool_sa_name                            = values.tenant_nodepool_sa_name
+      tenant_nodepool_sa_email                           = "${values.tenant_nodepool_sa_name}@${local.service_account_domain}"
+      tenant_apps_sa_name                                = values.tenant_apps_sa_name
+      tenant_apps_sa_email                               = "${values.tenant_apps_sa_name}@${local.service_account_domain}"
+      tenant_apps_kubernetes_service_account_name        = values.tenant_apps_kubernetes_service_account_name
+      tenant_apps_workload_identity_service_account_name = values.tenant_apps_workload_identity_service_account_name
+    }
+  }
+
+  # This is the final map to use
+  tenants = {
+    for name, values in local._tenants_intermediate : name => {
+      tenant_name                                        = values.tenant_name
+      tenant_nodepool_name                               = values.tenant_nodepool_name
+      tenant_nodepool_sa_name                            = values.tenant_nodepool_sa_name
+      tenant_nodepool_sa_email                           = values.tenant_nodepool_sa_email
+      tenant_nodepool_sa_iam_email                       = "serviceAccount:${values.tenant_nodepool_sa_email}"
+      tenant_apps_sa_name                                = values.tenant_apps_sa_name
+      tenant_apps_sa_email                               = values.tenant_apps_sa_email
+      tenant_apps_sa_iam_email                           = "serviceAccount:${values.tenant_apps_sa_email}"
+      tenant_apps_kubernetes_service_account_name        = values.tenant_apps_kubernetes_service_account_name
+      tenant_apps_workload_identity_service_account_name = values.tenant_apps_workload_identity_service_account_name
+
+      kubernetes_templates_configuration_values = {
+        namespace_name = values.tenant_name
+      }
+    }
+  }
+
+  service_account_domain = "${var.cluster_project_id}.iam.gserviceaccount.com"
+
+  node_pool_service_account_names = [
+    for tenant in local.tenants : tenant.tenant_nodepool_sa_name
+  ]
+
+  node_pool_service_account_emails = [
+    for tenant in local.tenants : tenant.tenant_nodepool_sa_email
+  ]
+
+  node_pool_service_account_iam_emails = [
+    for tenant in local.tenants : tenant.tenant_nodepool_sa_iam_email
+  ]
+
+  apps_service_account_names = [
+    for tenant in local.tenants : tenant.tenant_apps_sa_name
+  ]
+
+  apps_service_account_emails = [
+    for tenant in local.tenants : tenant.tenant_apps_sa_email
+  ]
+
+  apps_service_account_iam_emails = [
+    for tenant in local.tenants : tenant.tenant_apps_sa_iam_email
+  ]
 
   # Put all service account names in a list so we can create them with a single
   # google_service_account resource
   service_account_names = concat(
-    [for tenant in local.tenants : tenant.tenant_nodepool_sa_name],
-    [for tenant in local.tenants : tenant.tenant_apps_sa_name],
+    local.node_pool_service_account_names,
+    local.apps_service_account_names,
   )
 
   tenant_apps_kubernetes_service_account_name = "fl-ksa"
@@ -40,4 +102,10 @@ variable "federated_learning_tenant_names" {
   default     = ["fl-1"]
   description = "List of named tenants to be created in the cluster. Each tenant gets a dedicated node pool and Kubernetes namespace, isolated from other tenants."
   type        = list(string)
+}
+
+variable "federated_learning_node_pool_machine_type" {
+  default     = "n4-standard-8"
+  description = "Machine type of the node pool"
+  type        = string
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/.terraform.lock.hcl
@@ -21,22 +21,21 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "6.12.0"
-  constraints = "6.12.0"
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
   hashes = [
-    "h1:QlFR+Er67bwpvNoRptrJ9MY5E0GFOyoecMIaI0fF/t0=",
-    "zh:01ccef122918871d26a00dd7418fdbd62aa5433b31d2baf58ca6b8b512d7567d",
-    "zh:1d5b72c26dd5143a7d55674912ee4ffab0aaf44f7a998b4878ea0c37256740eb",
-    "zh:45588f2ad7e5c24ed444ce17041c6d3d02fea116bf0cb1fa416d2d6df78923c0",
-    "zh:6552cf328df297f9dec9b251a02a9be50f59d4ecc99cc8da48ec580d37b24067",
-    "zh:982d7adc9be96d47a4425bd1d32ca67a38b72d2ca535f66b3de5a99c7bf5213b",
-    "zh:99028261de774304d536e25f9d65dee1ce13f3e5111ded8afb691294a6bfbdf4",
-    "zh:a1c5e3efe2b3403883c3ba98d8b1d2a9599b327cfae4f67ed41c35f9c9971473",
-    "zh:a8b30370f4cc22af70a9054f773f15b96ee40fcc9f292e1443b872ce8ea369ab",
-    "zh:ac7101061e9a54c28b6ff634de6fab38c4f71f23c9dbc88828c1a62cbe0871c5",
-    "zh:f3adfa744e9da50bfe5cf334c8ffcb6ccc57e8fcbd4ddd0d3a548f44a229c849",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fefc9adf1719d4e3c0d4018e5c3483668874e4f1d57b8d0f052d3469b43d99e1",
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
   ]
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/configmanagement.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/configmanagement_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "cluster" {
+  location = var.cluster_region
+  name     = local.cluster_name
+  project  = data.google_project.default.project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/common/policy-controller-constraints.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/common/policy-controller-constraints.yaml
@@ -1,0 +1,212 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adds selected constraints from the PolicyController library
+# https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library
+
+---
+# Prevent Services of type NodePort
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockNodePort
+metadata:
+  name: block-node-port
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+---
+# Prevent the creation of known resources that expose workloads to external IPs.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoExternalServices
+metadata:
+  name: no-external-services
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+      - apiGroups: ["networking.k8s.io"]
+        kinds: ["Ingress"]
+      - apiGroups: ["networking.istio.io"]
+        kinds: ["Gateway"]
+    excludedNamespaces: ["istio-egress", "istio-ingress", "istio-system"]
+---
+# In tenant namespaces, only allow images to be pulled from
+# a named set of repositories
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAllowedRepos
+metadata:
+  name: known-repos-only
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+  parameters:
+    repos:
+      - "gcr.io/"
+      - "eu.gcr.io/"
+      - "us-docker.pkg.dev/"
+      - "europe-docker.pkg.dev/"
+---
+# Service mesh DestinationRules must enable TLS
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DestinationRuleTLSEnabled
+metadata:
+  name: istio-destination-rule-tls-required
+spec:
+  match:
+    kinds:
+      - apiGroups: ["networking.istio.io"]
+        kinds: ["DestinationRule"]
+---
+# prevent privileged containers
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPPrivilegedContainer
+metadata:
+  name: psp-privileged-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      ["istio-egress", "istio-ingress", "istio-system", "kube-system"]
+---
+# prevent hostPath volumes
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: psp-host-filesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      ["istio-egress", "istio-ingress", "istio-system", "kube-system"]
+  parameters:
+    allowedHostPaths: []
+---
+# prevent privilege escalation
+# Applied in tenant namespaces only
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: psp-allow-privilege-escalation-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+---
+# Require read only filesystem
+# Applied in tenant namespaces only
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPReadOnlyRootFilesystem
+metadata:
+  name: psp-readonlyrootfilesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+---
+# Enforce the istio ingressgateway label usage only on ingressgateway pods.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmIngressgatewayLabel
+metadata:
+  name: asm-ingressgateway-label-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Pod
+---
+# Enforce all PeerAuthentications cannot overwrite strict mtls
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmPeerAuthnStrictMtls
+metadata:
+  name: asm-peer-authn-strict-mtls-constraint
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - PeerAuthentication
+  parameters:
+    strictnessLevel: High
+---
+# Enforce the istio proxy sidecar always been injected to workload pods
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmSidecarInjection
+metadata:
+  name: asm-sidecar-injection-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Pod
+  parameters:
+    strictnessLevel: High
+---
+# Requires that STRICT Istio mutual TLS is always specified when using
+# PeerAuthentication. This constraint also ensures that the deprecated Policy
+# and MeshPolicy resources enforce STRICT mutual TLS.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: PolicyStrictOnly
+metadata:
+  name: peerauthentication-strict-constraint
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - PeerAuthentication
+---
+# Enforce the AuthorizationPolicy safe patterns.
+# Reference:
+# https://istio.io/latest/docs/ops/best-practices/security/#safer-authorization-policy-patterns
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmAuthzPolicySafePattern
+metadata:
+  name: asm-authz-policy-safe-pattern-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - AuthorizationPolicy
+  parameters:
+    strictnessLevel: High

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/.dockerignore
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/Dockerfile
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.7-labs
+
+FROM scratch
+
+COPY \
+  --exclude=Dockerfile \
+  . /

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/main.tf
@@ -1,0 +1,114 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  push_container_image_script_path = "${path.module}/scripts/build-push-container-image.sh"
+
+  config_management_files_path                    = "${path.module}/files"
+  config_management_common_files_path             = "${local.config_management_files_path}/common"
+  config_management_oci_descriptors_path          = "${local.config_management_files_path}/oci_descriptors"
+  config_management_templates_directory_path      = "${path.module}/templates"
+  namespace_configuration_template_directory_path = "${local.config_management_templates_directory_path}/namespace_configuration"
+
+  config_management_destination_directory_path                 = "${local.config_management_files_path}/config_management"
+  config_management_common_files_destination_directory_path    = "${local.config_management_destination_directory_path}/common"
+  config_management_oci_descriptors_destination_directory_path = local.config_management_destination_directory_path
+  namespace_configuration_destination_directory_path           = "${local.config_management_destination_directory_path}/namespace_configuration"
+
+  config_management_common_files          = flatten([for _, file in flatten(fileset(local.config_management_common_files_path, "**")) : file])
+  config_management_oci_descriptors_files = flatten([for _, file in flatten(fileset(local.config_management_oci_descriptors_path, "**")) : file])
+  namespace_configuration_template_files  = flatten([for _, file in flatten(fileset(local.namespace_configuration_template_directory_path, "**")) : file])
+
+  namespaces_configuration = flatten([
+    for tenant in local.tenants : [
+      for template_file in local.namespace_configuration_template_files : {
+        destination_file_path     = "${local.namespace_configuration_destination_directory_path}/${tenant.tenant_name}/${template_file}"
+        template_source_file_path = "${local.namespace_configuration_template_directory_path}/${template_file}"
+        template_variables        = tenant.kubernetes_templates_configuration_values
+      }
+    ]
+  ])
+}
+
+resource "local_file" "common_configuration" {
+  for_each = toset(local.config_management_common_files)
+
+  file_permission = "0644"
+  filename        = "${local.config_management_common_files_destination_directory_path}/${each.value}"
+  source          = "${local.config_management_common_files_path}/${each.value}"
+}
+
+resource "local_file" "oci_descriptors_configuration" {
+  for_each = toset(local.config_management_oci_descriptors_files)
+
+  file_permission = "0644"
+  filename        = "${local.config_management_oci_descriptors_destination_directory_path}/${each.value}"
+  source          = "${local.config_management_oci_descriptors_path}/${each.value}"
+}
+
+resource "local_file" "namespace_configuration" {
+  for_each = {
+    for namespace_config in local.namespaces_configuration : namespace_config.destination_file_path => namespace_config
+  }
+
+  content = templatefile(
+    each.value.template_source_file_path,
+    each.value.template_variables
+  )
+  file_permission = "0644"
+  filename        = each.value.destination_file_path
+}
+
+resource "terraform_data" "config_management_oci_archive_push" {
+
+  provisioner "local-exec" {
+    command = local.push_container_image_script_path
+
+    environment = {
+      CONTAINER_IMAGE_BUILD_CONTEXT_PATH = local.config_management_destination_directory_path
+      CONTAINER_IMAGE_REPOSITORY_DOMAIN  = local.oci_repo_domain
+      CONTAINER_IMAGE_REPOSITORY_URL     = local.oci_repo_url
+      CONTAINER_IMAGE_DESTINATION_TAG    = local.oci_sync_repo_url
+    }
+  }
+
+  triggers_replace = [
+    # Trigger whenever the contents of source directories or template configuration values change.
+    # Don't depend on destination directory content because it might change between plan and apply.
+    sha512(join("", [for f in fileset(local.config_management_common_files_path, "**") : filesha512("${local.config_management_common_files_path}/${f}")])),
+    sha512(join("", [for f in fileset(local.config_management_oci_descriptors_path, "**") : filesha512("${local.config_management_oci_descriptors_path}/${f}")])),
+    sha512(join("", [for f in fileset(local.namespace_configuration_template_directory_path, "**") : filesha512("${local.namespace_configuration_template_directory_path}/${f}")])),
+    # Trigger whenever the namespace configuration changes
+    local.namespaces_configuration,
+    # Trigger whenever the contents of the container image push script changes
+    filesha512(local.push_container_image_script_path),
+    # Trigger whenever destination paths change
+    local.config_management_destination_directory_path,
+    local.config_management_common_files_destination_directory_path,
+    local.config_management_oci_descriptors_destination_directory_path,
+    local.namespace_configuration_destination_directory_path,
+    # Trigger whenever OCI container image repository coordinates change
+    local.oci_repo_domain,
+    local.oci_repo_url,
+    local.oci_sync_repo_url,
+  ]
+
+  # Wait for files to be there before attempting to build the OCI container image containing
+  # configuration files
+  depends_on = [
+    local_file.common_configuration,
+    local_file.oci_descriptors_configuration,
+    local_file.namespace_configuration,
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "cluster" {
+  project_id = var.cluster_project_id
+}
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/scripts/build-push-container-image.sh
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/scripts/build-push-container-image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+docker build \
+  --tag "${CONTAINER_IMAGE_DESTINATION_TAG}" \
+  "${CONTAINER_IMAGE_BUILD_CONTEXT_PATH}"
+
+gcloud auth configure-docker "${CONTAINER_IMAGE_REPOSITORY_DOMAIN}"
+
+docker push "${CONTAINER_IMAGE_DESTINATION_TAG}"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/mutations.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/mutations.yaml
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PolicyController mutations.
+# https://cloud.google.com/anthos-config-management/docs/how-to/mutation#writing_mutators
+---
+# Adds a node affinity to all pods in a specific namespace
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: mutator-add-nodeaffinity-${namespace_name}
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+  match:
+    namespaces:
+      - "${namespace_name}"
+  location: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms"
+  parameters:
+    assign:
+      value:
+        - matchExpressions:
+            - key: "tenant"
+              operator: In
+              values:
+                - "${namespace_name}"
+---
+# Adds a toleration to all pods in a specific namespace so they can be deployed
+# on nodes that belong to this tenant.
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: mutator-add-toleration-${namespace_name}
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+  match:
+    namespaces:
+      - "${namespace_name}"
+  location: "spec.tolerations"
+  parameters:
+    assign:
+      value:
+        - key: "tenant"
+          operator: "Equal"
+          value: "${namespace_name}"
+          effect: "NoExecute"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/namespace.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/namespace.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace_name}
+  labels:
+    tenant-ns: "true"
+    # Allow Cloud Service Mesh to manage the workloads in the namespace
+    # Ref: https://cloud.google.com/service-mesh/docs/managed/select-a-release-channel#injection_labels
+    istio.io/rev: asm-managed

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/network-policy.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/network-policy.yaml
@@ -1,0 +1,134 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny-all
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-within-own-namespace
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ${namespace_name}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ${namespace_name}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-metadata-server
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock: # For GKE dataplane v2
+            cidr: 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 80
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.252/32
+        - ipBlock:
+            cidr: 127.0.0.1/32
+      ports:
+        - protocol: TCP
+          port: 988
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-istio-system
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-istio-egress
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-kube-system-dns
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-to-private-google-apis
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 199.36.153.8/30

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/versions.tf
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.2"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_policy_controller_deploy-v1"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/.terraform.lock.hcl
@@ -20,23 +20,3 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "6.12.0"
-  constraints = "6.12.0"
-  hashes = [
-    "h1:QlFR+Er67bwpvNoRptrJ9MY5E0GFOyoecMIaI0fF/t0=",
-    "zh:01ccef122918871d26a00dd7418fdbd62aa5433b31d2baf58ca6b8b512d7567d",
-    "zh:1d5b72c26dd5143a7d55674912ee4ffab0aaf44f7a998b4878ea0c37256740eb",
-    "zh:45588f2ad7e5c24ed444ce17041c6d3d02fea116bf0cb1fa416d2d6df78923c0",
-    "zh:6552cf328df297f9dec9b251a02a9be50f59d4ecc99cc8da48ec580d37b24067",
-    "zh:982d7adc9be96d47a4425bd1d32ca67a38b72d2ca535f66b3de5a99c7bf5213b",
-    "zh:99028261de774304d536e25f9d65dee1ce13f3e5111ded8afb691294a6bfbdf4",
-    "zh:a1c5e3efe2b3403883c3ba98d8b1d2a9599b327cfae4f67ed41c35f9c9971473",
-    "zh:a8b30370f4cc22af70a9054f773f15b96ee40fcc9f292e1443b872ce8ea369ab",
-    "zh:ac7101061e9a54c28b6ff634de6fab38c4f71f23c9dbc88828c1a62cbe0871c5",
-    "zh:f3adfa744e9da50bfe5cf334c8ffcb6ccc57e8fcbd4ddd0d3a548f44a229c849",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fefc9adf1719d4e3c0d4018e5c3483668874e4f1d57b8d0f052d3469b43d99e1",
-  ]
-}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "cluster" {
+  location = var.cluster_region
+  name     = local.cluster_name
+  project  = data.google_project.default.project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
@@ -1,0 +1,79 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_container_node_pool" "fl_container_node_pool" {
+  for_each = local.tenants
+
+  cluster            = data.google_container_cluster.cluster.name
+  initial_node_count = 1
+  location           = var.cluster_region
+  name               = each.value.tenant_nodepool_name
+  project            = data.google_project.default.project_id
+
+  autoscaling {
+    location_policy      = "BALANCED"
+    total_max_node_count = 32
+    total_min_node_count = 1
+  }
+
+  network_config {
+    enable_private_nodes = true
+  }
+
+  node_config {
+    enable_confidential_storage = var.cluster_confidential_nodes_enabled
+    machine_type                = var.federated_learning_node_pool_machine_type
+    service_account             = each.value.tenant_nodepool_sa_email
+
+    labels = {
+      "federated-learning-tenant" : each.value.tenant_name
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    confidential_nodes {
+      enabled = var.cluster_confidential_nodes_enabled
+    }
+
+    gcfs_config {
+      enabled = true
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+
+    taint {
+      effect = "NO_EXECUTE"
+      key    = "federated-learning-tenant"
+      value  = each.value.tenant_name
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      initial_node_count,
+      node_config[0].labels,
+      node_config[0].taint,
+    ]
+  }
+
+  timeouts {
+    create = "30m"
+    update = "20m"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_container_node_pool_deploy-v1"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/.terraform.lock.hcl
@@ -20,23 +20,3 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "6.12.0"
-  constraints = "6.12.0"
-  hashes = [
-    "h1:QlFR+Er67bwpvNoRptrJ9MY5E0GFOyoecMIaI0fF/t0=",
-    "zh:01ccef122918871d26a00dd7418fdbd62aa5433b31d2baf58ca6b8b512d7567d",
-    "zh:1d5b72c26dd5143a7d55674912ee4ffab0aaf44f7a998b4878ea0c37256740eb",
-    "zh:45588f2ad7e5c24ed444ce17041c6d3d02fea116bf0cb1fa416d2d6df78923c0",
-    "zh:6552cf328df297f9dec9b251a02a9be50f59d4ecc99cc8da48ec580d37b24067",
-    "zh:982d7adc9be96d47a4425bd1d32ca67a38b72d2ca535f66b3de5a99c7bf5213b",
-    "zh:99028261de774304d536e25f9d65dee1ce13f3e5111ded8afb691294a6bfbdf4",
-    "zh:a1c5e3efe2b3403883c3ba98d8b1d2a9599b327cfae4f67ed41c35f9c9971473",
-    "zh:a8b30370f4cc22af70a9054f773f15b96ee40fcc9f292e1443b872ce8ea369ab",
-    "zh:ac7101061e9a54c28b6ff634de6fab38c4f71f23c9dbc88828c1a62cbe0871c5",
-    "zh:f3adfa744e9da50bfe5cf334c8ffcb6ccc57e8fcbd4ddd0d3a548f44a229c849",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fefc9adf1719d4e3c0d4018e5c3483668874e4f1d57b8d0f052d3469b43d99e1",
-  ]
-}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_networking.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_networking.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/networking.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_networking_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_networking_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/networking_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/container_cluster.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "cluster" {
+  location = var.cluster_region
+  name     = local.cluster_name
+  project  = data.google_project.default.project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/main.tf
@@ -1,0 +1,165 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_compute_network_firewall_policy" "federated_learning_fw_policy" {
+  description = "Federated learning firewall policy"
+  name        = "${local.cluster_name}-federated-learning-firewall-policy"
+  project     = data.google_project.default.project_id
+}
+
+resource "google_compute_network_firewall_policy_association" "federated_learning_vpc_associations" {
+  name              = "${local.cluster_name}-federated-learning-firewall-policy-association"
+  attachment_target = data.google_compute_network.main_vpc_network.id
+  firewall_policy   = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  project           = data.google_project.default.project_id
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_deny_all" {
+  action                  = "deny"
+  description             = "Default deny egress from node pools"
+  direction               = "EGRESS"
+  enable_logging          = true
+  firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority                = 65535
+  project                 = data.google_project.default.project_id
+  rule_name               = "${local.cluster_name}-node-pools-deny-egress"
+  target_service_accounts = local.node_pool_service_account_emails
+
+  match {
+    dest_ip_ranges = ["0.0.0.0/0"]
+
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_allow_egress_to_cluster" {
+  action                  = "allow"
+  description             = "Allow egress from node pools to cluster nodes, pods and services"
+  direction               = "EGRESS"
+  enable_logging          = true
+  firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority                = 1000
+  project                 = data.google_project.default.project_id
+  rule_name               = "${local.cluster_name}-node-pools-allow-egress-nodes-pods-services"
+  target_service_accounts = local.node_pool_service_account_emails
+
+  match {
+    dest_ip_ranges = concat(
+      local.cluster_subnetwork_secondary_ip_ranges,
+      [data.google_container_cluster.cluster.services_ipv4_cidr]
+    )
+
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_allow_egress_to_k8s_api" {
+  action                  = "allow"
+  description             = "Allow egress from node pools to the Kubernetes API server"
+  direction               = "EGRESS"
+  enable_logging          = true
+  firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority                = 1001
+  project                 = data.google_project.default.project_id
+  rule_name               = "${local.cluster_name}-node-pools-allow-egress-api-server"
+  target_service_accounts = local.node_pool_service_account_emails
+
+  match {
+    dest_ip_ranges = [local.master_ipv4_cidr_block]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = [443, 10250]
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_allow_egress_to_private_google_access" {
+  action                  = "allow"
+  description             = "Allow egress from node pools to Google APIs via Private Google Access"
+  direction               = "EGRESS"
+  enable_logging          = true
+  firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority                = 1002
+  project                 = data.google_project.default.project_id
+  rule_name               = "${local.cluster_name}-node-pools-allow-egress-api-server"
+  target_service_accounts = local.node_pool_service_account_emails
+
+  match {
+    dest_ip_ranges = data.google_netblock_ip_ranges.private_google_access_netblock_ip_range.cidr_blocks_ipv4
+
+    layer4_configs {
+      ip_protocol = "tcp"
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_allow_intra_egress" {
+  action          = "allow"
+  description     = "Allow pods to communicate with each other and the control plane"
+  direction       = "EGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority        = 1003
+  project         = data.google_project.default.project_id
+  rule_name       = "${local.cluster_name}-intra-cluster-egress"
+
+  target_service_accounts = concat(
+    local.node_pool_service_account_emails,
+    local.apps_service_account_emails
+  )
+
+  match {
+    dest_ip_ranges = compact(
+      concat(
+        [
+          local.master_ipv4_cidr_block,
+          data.google_compute_subnetwork.region.ip_cidr_range,
+          data.google_container_cluster.cluster.tpu_ipv4_cidr_block,
+        ],
+        local.cluster_subnetwork_secondary_ip_ranges
+      )
+    )
+
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_allow_control_plane_ingress" {
+  action          = "allow"
+  description     = "Allow control plane to connect to pods for admission controllers and webhooks"
+  direction       = "INGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
+  priority        = 1004
+  project         = data.google_project.default.project_id
+  rule_name       = "${local.cluster_name}-control-plane-ingress-webhooks"
+
+  target_service_accounts = local.node_pool_service_account_emails
+
+  match {
+    src_ip_ranges = [local.master_ipv4_cidr_block]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = ["8443", "9443", "15017"]
+    }
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/networking.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/networking.tf
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_compute_network" "main_vpc_network" {
+  name    = local.network_name
+  project = google_project_service.compute_googleapis_com.project
+}
+
+data "google_compute_subnetwork" "region" {
+  name    = local.subnetwork_name
+  project = data.google_project.default.project_id
+  region  = var.cluster_region
+}
+
+locals {
+  cluster_subnetwork_secondary_ip_ranges = [for range in toset(data.google_compute_subnetwork.region.secondary_ip_range) : range.ip_cidr_range]
+  master_ipv4_cidr_block                 = data.google_container_cluster.cluster.private_cluster_config[0].master_ipv4_cidr_block
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/private_google_access.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/private_google_access.tf
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_netblock_ip_ranges" "private_google_access_netblock_ip_range" {
+  range_type = "private-googleapis"
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/project.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}
+
+resource "google_project_service" "compute_googleapis_com" {
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = data.google_project.default.project_id
+  service                    = "compute.googleapis.com"
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_firewall_deploy-v1"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/main.tf
@@ -12,11 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  node_pool_service_accounts_iam_roles_setproduct = setproduct(local.cluster_sa_roles, local.node_pool_service_account_iam_emails)
+
+  node_pool_service_accounts_iam_members = {
+    for entry in local.node_pool_service_accounts_iam_roles_setproduct : "${entry[0]}-${entry[1]}" => entry
+  }
+}
+
 resource "google_service_account" "federated_learning_service_account" {
   for_each = toset(local.service_account_names)
 
-  account_id   = lower(each.value)
+  account_id   = each.value
   description  = "Terraform-managed service account for the federated learning use case in cluster ${local.cluster_name}"
   display_name = "${local.cluster_name}-${each.value} service account"
   project      = google_project_service.iam_googleapis_com.project
+}
+
+resource "google_project_iam_member" "node_pool_service_account" {
+  for_each = local.node_pool_service_accounts_iam_members
+
+  member  = each.value[1]
+  project = google_project_service.iam_googleapis_com.project
+  role    = each.value[0]
+
+  depends_on = [
+    # Wait for service account creation before attempting to assign roles
+    google_service_account.federated_learning_service_account
+  ]
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/.terraform.lock.hcl
@@ -20,23 +20,3 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "6.12.0"
-  constraints = "6.12.0"
-  hashes = [
-    "h1:QlFR+Er67bwpvNoRptrJ9MY5E0GFOyoecMIaI0fF/t0=",
-    "zh:01ccef122918871d26a00dd7418fdbd62aa5433b31d2baf58ca6b8b512d7567d",
-    "zh:1d5b72c26dd5143a7d55674912ee4ffab0aaf44f7a998b4878ea0c37256740eb",
-    "zh:45588f2ad7e5c24ed444ce17041c6d3d02fea116bf0cb1fa416d2d6df78923c0",
-    "zh:6552cf328df297f9dec9b251a02a9be50f59d4ecc99cc8da48ec580d37b24067",
-    "zh:982d7adc9be96d47a4425bd1d32ca67a38b72d2ca535f66b3de5a99c7bf5213b",
-    "zh:99028261de774304d536e25f9d65dee1ce13f3e5111ded8afb691294a6bfbdf4",
-    "zh:a1c5e3efe2b3403883c3ba98d8b1d2a9599b327cfae4f67ed41c35f9c9971473",
-    "zh:a8b30370f4cc22af70a9054f773f15b96ee40fcc9f292e1443b872ce8ea369ab",
-    "zh:ac7101061e9a54c28b6ff634de6fab38c4f71f23c9dbc88828c1a62cbe0871c5",
-    "zh:f3adfa744e9da50bfe5cf334c8ffcb6ccc57e8fcbd4ddd0d3a548f44a229c849",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fefc9adf1719d4e3c0d4018e5c3483668874e4f1d57b8d0f052d3469b43d99e1",
-  ]
-}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_terraform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_terraform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_terraform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_terraform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/main.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account_iam_member" "fl_workload_identity_service_account_iam_member" {
+  for_each = local.tenants
+
+  service_account_id = data.google_service_account.cluster_service_account[each.key].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = each.value.tenant_apps_workload_identity_service_account_name
+}
+
+data "google_service_account" "cluster_service_account" {
+  for_each = local.tenants
+
+  account_id = each.value.tenant_apps_sa_name
+  project    = google_project_service.iam_googleapis_com.project
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/output.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/output.tf
@@ -1,0 +1,13 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/project.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}
+
+resource "google_project_service" "iam_googleapis_com" {
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = data.google_project.default.project_id
+  service                    = "iam.googleapis.com"
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/workload_identity/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_workload_identity_deploy-v1"
+  }
+}

--- a/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
+++ b/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
@@ -34,7 +34,6 @@ steps:
     entrypoint: "ash"
     args:
       - "-x"
-      - "-e"
       - "-u"
       - "-c"
       - |


### PR DESCRIPTION
- Configure firewall policies for the federated learning use case
- Fix an issue with the core `teardown.sh` script: remove backend configuration only when destroying the core `initialize` terraservice, instead of running it in any case after destroying the Terraservices in `CORE_TERRASERVICES_DESTROY` because `CORE_TERRASERVICES_DESTROY` might not include `initialize`.
- Fix an issue with the federated learning use case `teardown.sh` script: ensure that terraservices are destroyed in order.