### PR TITLE
Configure application-level encryption for federated learning

### DIFF
--- a/platforms/gke/base/core/deploy.sh
+++ b/platforms/gke/base/core/deploy.sh
@@ -17,8 +17,21 @@ set -o errexit
 
 start_timestamp=$(date +%s)
 
-# Disable gke_enterprise/servicemesh due to b/376312292
-declare -a terraservices=${CORE_TERRASERVICES_APPLY:-("networking" "container_cluster" "container_node_pool" "gke_enterprise/fleet_membership" "workloads/kueue")}
+declare -a terraservices
+if [[ -v CORE_TERRASERVICES_APPLY ]]; then
+    terraservices=("${CORE_TERRASERVICES_APPLY[@]}")
+else
+    terraservices=(
+        "networking"
+        "container_cluster"
+        "container_node_pool"
+        "gke_enterprise/fleet_membership"
+        # Disable gke_enterprise/servicemesh due to b/376312292
+        # "gke_enterprise/servicemesh"
+        "workloads/kueue"
+    )
+fi
+echo "Core platform terraservices to provision: ${terraservices[*]}"
 
 source ${ACP_PLATFORM_BASE_DIR}/_shared_config/scripts/set_environment_variables.sh ${ACP_PLATFORM_BASE_DIR}/_shared_config
 

--- a/platforms/gke/base/core/teardown.sh
+++ b/platforms/gke/base/core/teardown.sh
@@ -17,7 +17,21 @@ set -o errexit
 
 start_timestamp=$(date +%s)
 
-declare -a terraservices=${CORE_TERRASERVICES_DESTROY:-("workloads/kueue" "gke_enterprise/fleet_membership" "container_node_pool" "container_cluster" "networking")}
+declare -a terraservices
+if [[ -v CORE_TERRASERVICES_DESTROY ]]; then
+    terraservices=("${CORE_TERRASERVICES_DESTROY[@]}")
+else
+    terraservices=(
+        "workloads/kueue"
+        # Disable gke_enterprise/servicemesh due to b/376312292
+        # "gke_enterprise/servicemesh"
+        "gke_enterprise/fleet_membership"
+        "container_node_pool"
+        "container_cluster"
+        "networking"
+    )
+fi
+echo "Core platform terraservices to destroy: ${terraservices[*]}"
 
 source ${ACP_PLATFORM_BASE_DIR}/_shared_config/scripts/set_environment_variables.sh ${ACP_PLATFORM_BASE_DIR}/_shared_config
 

--- a/platforms/gke/base/use-cases/federated-learning/teardown.sh
+++ b/platforms/gke/base/use-cases/federated-learning/teardown.sh
@@ -35,10 +35,11 @@ echo "Destroying the core platform"
 "${ACP_PLATFORM_CORE_DIR}/teardown.sh"
 
 for configuration_variable in "${TERRAFORM_CLUSTER_CONFIGURATION[@]}"; do
-  configuration_variable_name="$(echo "${configuration_variable}" | awk ' { print $1 }'))"
-  sed -i "/${configuration_variable_name}/d" "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
+  remove_terraform_configuration_variable_from_file "${configuration_variable}" "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
 done
-terraform fmt "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
+for configuration_variable in "${TERRAFORM_CORE_INITIALIZE_CONFIGURATION[@]}"; do
+  remove_terraform_configuration_variable_from_file "${configuration_variable}" "${ACP_PLATFORM_SHARED_CONFIG_INITIALIZE_AUTO_VARS_FILE}"
+done
 
 end_timestamp_federated_learning=$(date +%s)
 total_runtime_value_federated_learning=$((end_timestamp_federated_learning - start_timestamp_federated_learning))

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.12.0"
+  constraints = "6.12.0"
+  hashes = [
+    "h1:rvZHMkoxkHrBYQXb/waoZiD2oo3FS1AF8HoWHlb6SN8=",
+    "zh:14701aa307a832d99f567b8056a4c5e4ee5a403d984c98f024deee7507a3f29c",
+    "zh:344eca00ffb2643c2fa7f52f069b659d50bb4c9369df4cad96ea0fadb54282c8",
+    "zh:5fb57c0acfd4d30a39941900040d5518a909d8c975af0c4366a7bfd0d0bb09a8",
+    "zh:617a77048a5b9aa568e8bc706cc84307a237b2dd0e49709028b283f8bbe42475",
+    "zh:677837a05fefe0342cf4d4bdc494e8fd4d62331cac947820e73df37e8f512688",
+    "zh:7b79f6e02474eef4a1480fc6589afb63ed16b25bf019b6056f9838e2845e2ef8",
+    "zh:7d891fceb5b15e81240d829f42e1a36e4c812bfc1abe7856756e59101932205f",
+    "zh:97f1e0ac799faf382426e070e888fac36b0867597b460dc95b0e7f657de21ba9",
+    "zh:9855f2f2f5919ff6a6a2c982439c910d28c8978ad18cd8f549a5d1ba9b4dc4c3",
+    "zh:ac551367180eb396af2a50244e80243d333d600a76002e29935262d76a02290b",
+    "zh:c354f34e6579933d21a98ce7f31f4ef8aeaceb04cfaedaff6d3f3c0be56b2c79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.5.2"
+  constraints = "2.5.2"
+  hashes = [
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_terraform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_terraform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_terraform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_terraform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/output.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/output.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
-  gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
-  gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
+output "cluster_database_encryption_key_id" {
+  description = "Id of the cluster database encryption key"
+  value       = google_kms_crypto_key.cluster_secrects_key.id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/project.tf
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
-  gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
-  gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}
+
+resource "google_project_service" "cloudkms_googleapis_com" {
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = data.google_project.default.project_id
+  service                    = "cloudkms.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/versions.tf
@@ -12,7 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
-  gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
-  gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_kms_deploy-v1"
+  }
 }


### PR DESCRIPTION
- Create Key management resources to enable application-level encryption for GKE in the `key_management_service` terraservice.
- Configure application-level encryption for the core GKE cluster by dynamically adding configuration variables to the core platform `.auto.tfvars` file.
- Fix a bug in the core platform `deploy.sh` and `teardown.sh` so they correctly pick up the array of terraservices to provision.
- Enable use case backend initialization by setting `initialize_backend_use_case_name`
- Ensure that the Terraform environment is initialized in `get_terraform_output`
- Centralize the logic to write and delete configuration variables in `common.sh` for future reuse