### PR TITLE
[1] feature: configure federated learning service accounts

### DIFF
--- a/platforms/gke/base/core/functions.sh
+++ b/platforms/gke/base/core/functions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ParseSeparatedBashArray() {
+  local STRING_TO_PARSE="${1}"
+  local -n DESTINATION_ARRAY="${2}"
+  local STRING_ARRAY_SEPARATOR="${3}"
+
+  echo "Parsing ${STRING_TO_PARSE} as a Bash array"
+
+  local -a PARSED_ARRAY
+  IFS="${STRING_ARRAY_SEPARATOR}" read -r -a PARSED_ARRAY <<<"${STRING_TO_PARSE}"
+  echo "Elements to add to ${!DESTINATION_ARRAY}: ${PARSED_ARRAY[*]}"
+
+  DESTINATION_ARRAY+=("${PARSED_ARRAY[@]}")
+  echo "${!DESTINATION_ARRAY} after adding options: ${DESTINATION_ARRAY[*]}"
+
+  unset -n DESTINATION_ARRAY
+}
+
+ParseSpaceSeparatedBashArray() {
+  ParseSeparatedBashArray "${1}" "${2}" " "
+}

--- a/platforms/gke/base/use-cases/federated-learning/common.sh
+++ b/platforms/gke/base/use-cases/federated-learning/common.sh
@@ -37,6 +37,7 @@ FEDERATED_LEARNING_SHARED_CONFIG_DIR="${FEDERATED_LEARNING_USE_CASE_TERRAFORM_DI
 # Terraservices that are necessary for the core platform
 federated_learning_core_platform_terraservices=(
   "key_management_service"
+  "service_account"
 )
 
 # shellcheck disable=SC2034 # Variable is used in other scripts

--- a/platforms/gke/base/use-cases/federated-learning/deploy.sh
+++ b/platforms/gke/base/use-cases/federated-learning/deploy.sh
@@ -26,10 +26,9 @@ start_timestamp_federated_learning=$(date +%s)
 echo "Initializing the core platform"
 # Don't provision any core platform terraservice becuase we just need
 # to initialize the terraform environment and remote backend
-declare -a CORE_TERRASERVICES_APPLY
-CORE_TERRASERVICES_APPLY=("initialize")
 # shellcheck disable=SC1091
-source "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
+CORE_TERRASERVICES_APPLY="initialize" \
+  "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
 
 echo "Preparing core platform configuration files"
 for configuration_variable in "${TERRAFORM_CLUSTER_CONFIGURATION[@]}"; do
@@ -51,10 +50,9 @@ fi
 edit_terraform_configuration_variable_value_in_file "cluster_database_encryption_key_name_placeholder" "${cluster_database_encryption_key_id}" "${ACP_PLATFORM_SHARED_CONFIG_CLUSTER_AUTO_VARS_FILE}"
 
 echo "Provisioning the core platform"
-# shellcheck disable=SC2034 # Variable is used in other scripts
-CORE_TERRASERVICES_APPLY=("networking" "container_cluster" "gke_enterprise/fleet_membership")
-# shellcheck disable=SC1091
-source "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
+# shellcheck disable=SC1091,SC2034 # Variable is used in other scripts
+CORE_TERRASERVICES_APPLY="networking container_cluster gke_enterprise/fleet_membership" \
+  "${ACP_PLATFORM_CORE_DIR}/deploy.sh"
 
 echo "Provisioning the use case resources"
 # shellcheck disable=SC2154 # variable defined in common.sh

--- a/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
@@ -15,4 +15,29 @@
 locals {
   gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
   gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
+
+  tenants = {
+    for name in var.federated_learning_tenant_names : name => {
+      tenant_name                                 = name
+      tenant_nodepool_name                        = format("%s-%s-p", local.cluster_name, name)
+      tenant_nodepool_sa_name                     = format("%s-%s-n", local.cluster_name, name)
+      tenant_apps_sa_name                         = format("%s-%s-a", local.cluster_name, name)
+      tenant_apps_kubernetes_service_account_name = local.tenant_apps_kubernetes_service_account_name
+    }
+  }
+
+  # Put all service account names in a list so we can create them with a single
+  # google_service_account resource
+  service_account_names = concat(
+    [for tenant in local.tenants : tenant.tenant_nodepool_sa_name],
+    [for tenant in local.tenants : tenant.tenant_apps_sa_name],
+  )
+
+  tenant_apps_kubernetes_service_account_name = "fl-ksa"
+}
+
+variable "federated_learning_tenant_names" {
+  default     = ["fl-1"]
+  description = "List of named tenants to be created in the cluster. Each tenant gets a dedicated node pool and Kubernetes namespace, isolated from other tenants."
+  type        = list(string)
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_image_repository/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_image_repository/main.tf
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 resource "google_artifact_registry_repository" "container_image_repository" {
-  location      = var.cluster_region
-  repository_id = "${local.unique_identifier_prefix}-fl-repository"
   description   = "Federated Learning container image repository"
   format        = "DOCKER"
+  location      = var.cluster_region
   project       = google_project_service.artifactregistry_googleapis_com.project
+  repository_id = "${local.unique_identifier_prefix}-fl-repository"
 
   cleanup_policies {
     action = "DELETE"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/private_google_access/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/private_google_access/main.tf
@@ -36,10 +36,10 @@ data "google_compute_network" "main_vpc_network" {
 }
 
 resource "google_dns_managed_zone" "private_google_access" {
-  project     = google_project_service.dns_googleapis_com.project
-  name        = "${local.unique_identifier_prefix}-private-google-apis"
-  dns_name    = "googleapis.com."
   description = "Private DNS zone for Google APIs"
+  dns_name    = "googleapis.com."
+  name        = "${local.unique_identifier_prefix}-private-google-apis"
+  project     = google_project_service.dns_googleapis_com.project
   visibility  = "private"
 
   private_visibility_config {
@@ -50,10 +50,10 @@ resource "google_dns_managed_zone" "private_google_access" {
 }
 
 resource "google_dns_managed_zone" "private_google_access_container_registry" {
-  project     = google_project_service.dns_googleapis_com.project
-  name        = "${local.unique_identifier_prefix}-private-google-access-container-registry"
-  dns_name    = "gcr.io."
   description = "Private DNS zone for Container Registry"
+  dns_name    = "gcr.io."
+  name        = "${local.unique_identifier_prefix}-private-google-access-container-registry"
+  project     = google_project_service.dns_googleapis_com.project
   visibility  = "private"
 
   private_visibility_config {
@@ -64,10 +64,10 @@ resource "google_dns_managed_zone" "private_google_access_container_registry" {
 }
 
 resource "google_dns_managed_zone" "private_google_access_artifact_registry" {
-  project     = google_project_service.dns_googleapis_com.project
-  name        = "${local.unique_identifier_prefix}-private-google-access-artifact-registry"
-  dns_name    = "pkg.dev."
   description = "Private DNS zone for Artifact Registry"
+  dns_name    = "pkg.dev."
+  name        = "${local.unique_identifier_prefix}-private-google-access-artifact-registry"
+  project     = google_project_service.dns_googleapis_com.project
   visibility  = "private"
 
   private_visibility_config {
@@ -79,10 +79,11 @@ resource "google_dns_managed_zone" "private_google_access_artifact_registry" {
 
 resource "google_dns_record_set" "private_google_access_cname" {
   managed_zone = google_dns_managed_zone.private_google_access.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = "*.${google_dns_managed_zone.private_google_access.dns_name}"
-  type         = "CNAME"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
+  type         = "CNAME"
+
   rrdatas = [
     google_dns_record_set.private_google_access_a.name,
   ]
@@ -90,19 +91,21 @@ resource "google_dns_record_set" "private_google_access_cname" {
 
 resource "google_dns_record_set" "private_google_access_a" {
   managed_zone = google_dns_managed_zone.private_google_access.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = "private.${google_dns_managed_zone.private_google_access.dns_name}"
-  type         = "A"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
-  rrdatas      = local.private_google_access_ips
+  type         = "A"
+
+  rrdatas = local.private_google_access_ips
 }
 
 resource "google_dns_record_set" "private_google_access_container_registry_cname" {
   managed_zone = google_dns_managed_zone.private_google_access_container_registry.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = "*.${google_dns_managed_zone.private_google_access_container_registry.dns_name}"
-  type         = "CNAME"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
+  type         = "CNAME"
+
   rrdatas = [
     google_dns_record_set.private_google_access_container_registry_a.name,
   ]
@@ -110,19 +113,21 @@ resource "google_dns_record_set" "private_google_access_container_registry_cname
 
 resource "google_dns_record_set" "private_google_access_container_registry_a" {
   managed_zone = google_dns_managed_zone.private_google_access_container_registry.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = google_dns_managed_zone.private_google_access_container_registry.dns_name
-  type         = "A"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
-  rrdatas      = local.private_google_access_ips
+  type         = "A"
+
+  rrdatas = local.private_google_access_ips
 }
 
 resource "google_dns_record_set" "private_google_access_artifact_registry_cname" {
   managed_zone = google_dns_managed_zone.private_google_access_artifact_registry.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = "*.${google_dns_managed_zone.private_google_access_artifact_registry.dns_name}"
-  type         = "CNAME"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
+  type         = "CNAME"
+
   rrdatas = [
     google_dns_record_set.private_google_access_artifact_registry_a.name,
   ]
@@ -130,9 +135,10 @@ resource "google_dns_record_set" "private_google_access_artifact_registry_cname"
 
 resource "google_dns_record_set" "private_google_access_artifact_registry_a" {
   managed_zone = google_dns_managed_zone.private_google_access_artifact_registry.name
-  project      = google_project_service.dns_googleapis_com.project
   name         = google_dns_managed_zone.private_google_access_artifact_registry.dns_name
-  type         = "A"
+  project      = google_project_service.dns_googleapis_com.project
   ttl          = 300
-  rrdatas      = local.private_google_access_ips
+  type         = "A"
+
+  rrdatas = local.private_google_access_ips
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.12.0"
+  constraints = "6.12.0"
+  hashes = [
+    "h1:rvZHMkoxkHrBYQXb/waoZiD2oo3FS1AF8HoWHlb6SN8=",
+    "zh:14701aa307a832d99f567b8056a4c5e4ee5a403d984c98f024deee7507a3f29c",
+    "zh:344eca00ffb2643c2fa7f52f069b659d50bb4c9369df4cad96ea0fadb54282c8",
+    "zh:5fb57c0acfd4d30a39941900040d5518a909d8c975af0c4366a7bfd0d0bb09a8",
+    "zh:617a77048a5b9aa568e8bc706cc84307a237b2dd0e49709028b283f8bbe42475",
+    "zh:677837a05fefe0342cf4d4bdc494e8fd4d62331cac947820e73df37e8f512688",
+    "zh:7b79f6e02474eef4a1480fc6589afb63ed16b25bf019b6056f9838e2845e2ef8",
+    "zh:7d891fceb5b15e81240d829f42e1a36e4c812bfc1abe7856756e59101932205f",
+    "zh:97f1e0ac799faf382426e070e888fac36b0867597b460dc95b0e7f657de21ba9",
+    "zh:9855f2f2f5919ff6a6a2c982439c910d28c8978ad18cd8f549a5d1ba9b4dc4c3",
+    "zh:ac551367180eb396af2a50244e80243d333d600a76002e29935262d76a02290b",
+    "zh:c354f34e6579933d21a98ce7f31f4ef8aeaceb04cfaedaff6d3f3c0be56b2c79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_terraform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_terraform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_terraform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_terraform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/terraform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/main.tf
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SHARED_CONFIG_PATHS=("${@}")
 
-for SHARED_CONFIG_PATH in "${SHARED_CONFIG_PATHS[@]}"; do
-  echo "Loading shared configuration(${SHARED_CONFIG_PATH})"
-  echo "-------------------------------------------------------------------------"
-  cd "${SHARED_CONFIG_PATH}" || exit 1
-  terraform init >/dev/null
-  terraform apply -auto-approve -input=false >/dev/null
-  terraform output
-  echo -e "-------------------------------------------------------------------------\n"
-  eval "$(terraform output | sed -r 's/(\".*\")|\s*/\1/g')"
-done
+resource "google_service_account" "federated_learning_service_account" {
+  for_each = toset(local.service_account_names)
+
+  account_id   = lower(each.value)
+  description  = "Terraform-managed service account for the federated learning use case in cluster ${local.cluster_name}"
+  display_name = "${local.cluster_name}-${each.value} service account"
+  project      = google_project_service.iam_googleapis_com.project
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/output.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/output.tf
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SHARED_CONFIG_PATHS=("${@}")
-
-for SHARED_CONFIG_PATH in "${SHARED_CONFIG_PATHS[@]}"; do
-  echo "Loading shared configuration(${SHARED_CONFIG_PATH})"
-  echo "-------------------------------------------------------------------------"
-  cd "${SHARED_CONFIG_PATH}" || exit 1
-  terraform init >/dev/null
-  terraform apply -auto-approve -input=false >/dev/null
-  terraform output
-  echo -e "-------------------------------------------------------------------------\n"
-  eval "$(terraform output | sed -r 's/(\".*\")|\s*/\1/g')"
-done

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/project.tf
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SHARED_CONFIG_PATHS=("${@}")
 
-for SHARED_CONFIG_PATH in "${SHARED_CONFIG_PATHS[@]}"; do
-  echo "Loading shared configuration(${SHARED_CONFIG_PATH})"
-  echo "-------------------------------------------------------------------------"
-  cd "${SHARED_CONFIG_PATH}" || exit 1
-  terraform init >/dev/null
-  terraform apply -auto-approve -input=false >/dev/null
-  terraform output
-  echo -e "-------------------------------------------------------------------------\n"
-  eval "$(terraform output | sed -r 's/(\".*\")|\s*/\1/g')"
-done
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}
+
+resource "google_project_service" "iam_googleapis_com" {
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = data.google_project.default.project_id
+  service                    = "iam.googleapis.com"
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/versions.tf
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-SHARED_CONFIG_PATHS=("${@}")
 
-for SHARED_CONFIG_PATH in "${SHARED_CONFIG_PATHS[@]}"; do
-  echo "Loading shared configuration(${SHARED_CONFIG_PATH})"
-  echo "-------------------------------------------------------------------------"
-  cd "${SHARED_CONFIG_PATH}" || exit 1
-  terraform init >/dev/null
-  terraform apply -auto-approve -input=false >/dev/null
-  terraform output
-  echo -e "-------------------------------------------------------------------------\n"
-  eval "$(terraform output | sed -r 's/(\".*\")|\s*/\1/g')"
-done
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_service_account_deploy-v1"
+  }
+}

--- a/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
+++ b/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
@@ -48,7 +48,7 @@ steps:
         export ACP_PLATFORM_CORE_DIR="/workspace/platforms/gke/base/core"
 
         export TF_VAR_cluster_project_id="${PROJECT_ID}"
-        export TF_VAR_platform_name="commit-${SHORT_SHA}-fl"
+        export TF_VAR_platform_name="${SHORT_SHA}-fl"
         export TF_VAR_terraform_project_id="${PROJECT_ID}"
 
         # Deploy the base platform and the use case


### PR DESCRIPTION
- Define a variable to define tenants.
- Define tenants local variables. For each tenant, define:
  - Name
  - Name of the node pool (will be used in the future)
  - Node pool service account name
  - workloads service account name
  - Kubernetes service account name (will be used in the future)
- Ensure that the IAM API is enabled
-  Create the Google Cloud service accounts
- Order resource attributes alphabetically

On the core platform side:

- Fix a few quoting issues in scripts
- Parse `CORE_TERRASERVICES_APPLY` and `CORE_TERRASERVICES_DESTROY` to build arrays so we don't need to `source` core platform scripts to use them.