### PR TITLE
[4] feat: configure fl node pool

### DIFF
--- a/platforms/gke/base/_shared_config/configmanagement_variables.tf
+++ b/platforms/gke/base/_shared_config/configmanagement_variables.tf
@@ -19,7 +19,8 @@ locals {
   git_creds_secret = var.configmanagement_git_credentials.secret_name == null ? "${var.platform_name}-git-creds" : var.configmanagement_git_credentials.secret_name
 
   oci_repo_id              = "${local.unique_identifier_prefix}-config-sync"
-  oci_repo_url             = "${var.cluster_region}-docker.pkg.dev/${data.google_project.cluster.project_id}/${local.oci_repo_id}"
+  oci_repo_domain          = "${var.cluster_region}-docker.pkg.dev"
+  oci_repo_url             = "${local.oci_repo_domain}/${data.google_project.cluster.project_id}/${local.oci_repo_id}"
   oci_root_sync_image      = "${local.oci_root_sync_image_name}:${local.oci_root_sync_image_tag}"
   oci_root_sync_image_name = "root-sync"
   oci_root_sync_image_tag  = "latest"

--- a/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
+++ b/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
@@ -30,6 +30,7 @@ resource "google_gke_hub_feature_membership" "cluster_policycontroller" {
 
   policycontroller {
     policy_controller_hub_config {
+      audit_interval_seconds    = 60
       install_spec              = "INSTALL_SPEC_ENABLED"
       log_denies_enabled        = true
       mutation_enabled          = true

--- a/platforms/gke/base/use-cases/federated-learning/common.sh
+++ b/platforms/gke/base/use-cases/federated-learning/common.sh
@@ -47,6 +47,7 @@ federated_learning_terraservices=(
   "private_google_access"
   "workload_identity"
   "container_node_pool"
+  "config_management"
 )
 
 # shellcheck disable=SC2034 # Variable is used in other scripts
@@ -59,6 +60,8 @@ core_platform_init_terraservices=(
 core_platform_terraservices=(
   "container_cluster"
   "gke_enterprise/fleet_membership"
+  "gke_enterprise/configmanagement/oci"
+  "gke_enterprise/policycontroller"
 )
 
 # shellcheck disable=SC2034 # Variable is used in other scripts

--- a/platforms/gke/base/use-cases/federated-learning/common.sh
+++ b/platforms/gke/base/use-cases/federated-learning/common.sh
@@ -46,6 +46,7 @@ federated_learning_terraservices=(
   "container_image_repository"
   "private_google_access"
   "workload_identity"
+  "container_node_pool"
 )
 
 # shellcheck disable=SC2034 # Variable is used in other scripts

--- a/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
@@ -55,6 +55,10 @@ locals {
       tenant_apps_sa_iam_email                           = "serviceAccount:${values.tenant_apps_sa_email}"
       tenant_apps_kubernetes_service_account_name        = values.tenant_apps_kubernetes_service_account_name
       tenant_apps_workload_identity_service_account_name = values.tenant_apps_workload_identity_service_account_name
+
+      kubernetes_templates_configuration_values = {
+        namespace_name = values.tenant_name
+      }
     }
   }
 

--- a/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
@@ -99,3 +99,9 @@ variable "federated_learning_tenant_names" {
   description = "List of named tenants to be created in the cluster. Each tenant gets a dedicated node pool and Kubernetes namespace, isolated from other tenants."
   type        = list(string)
 }
+
+variable "federated_learning_node_pool_machine_type" {
+  default     = "n4-standard-8"
+  description = "Machine type of the node pool"
+  type        = string
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/.terraform.lock.hcl
@@ -21,22 +21,21 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "6.12.0"
-  constraints = "6.12.0"
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
   hashes = [
-    "h1:QlFR+Er67bwpvNoRptrJ9MY5E0GFOyoecMIaI0fF/t0=",
-    "zh:01ccef122918871d26a00dd7418fdbd62aa5433b31d2baf58ca6b8b512d7567d",
-    "zh:1d5b72c26dd5143a7d55674912ee4ffab0aaf44f7a998b4878ea0c37256740eb",
-    "zh:45588f2ad7e5c24ed444ce17041c6d3d02fea116bf0cb1fa416d2d6df78923c0",
-    "zh:6552cf328df297f9dec9b251a02a9be50f59d4ecc99cc8da48ec580d37b24067",
-    "zh:982d7adc9be96d47a4425bd1d32ca67a38b72d2ca535f66b3de5a99c7bf5213b",
-    "zh:99028261de774304d536e25f9d65dee1ce13f3e5111ded8afb691294a6bfbdf4",
-    "zh:a1c5e3efe2b3403883c3ba98d8b1d2a9599b327cfae4f67ed41c35f9c9971473",
-    "zh:a8b30370f4cc22af70a9054f773f15b96ee40fcc9f292e1443b872ce8ea369ab",
-    "zh:ac7101061e9a54c28b6ff634de6fab38c4f71f23c9dbc88828c1a62cbe0871c5",
-    "zh:f3adfa744e9da50bfe5cf334c8ffcb6ccc57e8fcbd4ddd0d3a548f44a229c849",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fefc9adf1719d4e3c0d4018e5c3483668874e4f1d57b8d0f052d3469b43d99e1",
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
   ]
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/configmanagement.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_configmanagement_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/configmanagement_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "cluster" {
+  location = var.cluster_region
+  name     = local.cluster_name
+  project  = data.google_project.default.project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/common/policy-controller-constraints.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/common/policy-controller-constraints.yaml
@@ -1,0 +1,212 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adds selected constraints from the PolicyController library
+# https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library
+
+---
+# Prevent Services of type NodePort
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockNodePort
+metadata:
+  name: block-node-port
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+---
+# Prevent the creation of known resources that expose workloads to external IPs.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoExternalServices
+metadata:
+  name: no-external-services
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+      - apiGroups: ["networking.k8s.io"]
+        kinds: ["Ingress"]
+      - apiGroups: ["networking.istio.io"]
+        kinds: ["Gateway"]
+    excludedNamespaces: ["istio-egress", "istio-ingress", "istio-system"]
+---
+# In tenant namespaces, only allow images to be pulled from
+# a named set of repositories
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAllowedRepos
+metadata:
+  name: known-repos-only
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+  parameters:
+    repos:
+      - "gcr.io/"
+      - "eu.gcr.io/"
+      - "us-docker.pkg.dev/"
+      - "europe-docker.pkg.dev/"
+---
+# Service mesh DestinationRules must enable TLS
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DestinationRuleTLSEnabled
+metadata:
+  name: istio-destination-rule-tls-required
+spec:
+  match:
+    kinds:
+      - apiGroups: ["networking.istio.io"]
+        kinds: ["DestinationRule"]
+---
+# prevent privileged containers
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPPrivilegedContainer
+metadata:
+  name: psp-privileged-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      ["istio-egress", "istio-ingress", "istio-system", "kube-system"]
+---
+# prevent hostPath volumes
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: psp-host-filesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      ["istio-egress", "istio-ingress", "istio-system", "kube-system"]
+  parameters:
+    allowedHostPaths: []
+---
+# prevent privilege escalation
+# Applied in tenant namespaces only
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: psp-allow-privilege-escalation-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+---
+# Require read only filesystem
+# Applied in tenant namespaces only
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPReadOnlyRootFilesystem
+metadata:
+  name: psp-readonlyrootfilesystem
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaceSelector:
+      matchExpressions:
+        - key: federated-learning-tenant
+          operator: Exists
+---
+# Enforce the istio ingressgateway label usage only on ingressgateway pods.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmIngressgatewayLabel
+metadata:
+  name: asm-ingressgateway-label-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Pod
+---
+# Enforce all PeerAuthentications cannot overwrite strict mtls
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmPeerAuthnStrictMtls
+metadata:
+  name: asm-peer-authn-strict-mtls-constraint
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - PeerAuthentication
+  parameters:
+    strictnessLevel: High
+---
+# Enforce the istio proxy sidecar always been injected to workload pods
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmSidecarInjection
+metadata:
+  name: asm-sidecar-injection-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - ""
+        kinds:
+          - Pod
+  parameters:
+    strictnessLevel: High
+---
+# Requires that STRICT Istio mutual TLS is always specified when using
+# PeerAuthentication. This constraint also ensures that the deprecated Policy
+# and MeshPolicy resources enforce STRICT mutual TLS.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: PolicyStrictOnly
+metadata:
+  name: peerauthentication-strict-constraint
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - PeerAuthentication
+---
+# Enforce the AuthorizationPolicy safe patterns.
+# Reference:
+# https://istio.io/latest/docs/ops/best-practices/security/#safer-authorization-policy-patterns
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmAuthzPolicySafePattern
+metadata:
+  name: asm-authz-policy-safe-pattern-sample
+spec:
+  match:
+    kinds:
+      - apiGroups:
+          - security.istio.io
+        kinds:
+          - AuthorizationPolicy
+  parameters:
+    strictnessLevel: High

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/.dockerignore
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/Dockerfile
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/oci_descriptors/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.7-labs
+
+FROM scratch
+
+COPY \
+  --exclude=Dockerfile \
+  . /

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/main.tf
@@ -1,0 +1,114 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  push_container_image_script_path = "${path.module}/scripts/build-push-container-image.sh"
+
+  config_management_files_path                    = "${path.module}/files"
+  config_management_common_files_path             = "${local.config_management_files_path}/common"
+  config_management_oci_descriptors_path          = "${local.config_management_files_path}/oci_descriptors"
+  config_management_templates_directory_path      = "${path.module}/templates"
+  namespace_configuration_template_directory_path = "${local.config_management_templates_directory_path}/namespace_configuration"
+
+  config_management_destination_directory_path                 = "${local.config_management_files_path}/config_management"
+  config_management_common_files_destination_directory_path    = "${local.config_management_destination_directory_path}/common"
+  config_management_oci_descriptors_destination_directory_path = local.config_management_destination_directory_path
+  namespace_configuration_destination_directory_path           = "${local.config_management_destination_directory_path}/namespace_configuration"
+
+  config_management_common_files          = flatten([for _, file in flatten(fileset(local.config_management_common_files_path, "**")) : file])
+  config_management_oci_descriptors_files = flatten([for _, file in flatten(fileset(local.config_management_oci_descriptors_path, "**")) : file])
+  namespace_configuration_template_files  = flatten([for _, file in flatten(fileset(local.namespace_configuration_template_directory_path, "**")) : file])
+
+  namespaces_configuration = flatten([
+    for tenant in local.tenants : [
+      for template_file in local.namespace_configuration_template_files : {
+        destination_file_path     = "${local.namespace_configuration_destination_directory_path}/${tenant.tenant_name}/${template_file}"
+        template_source_file_path = "${local.namespace_configuration_template_directory_path}/${template_file}"
+        template_variables        = tenant.kubernetes_templates_configuration_values
+      }
+    ]
+  ])
+}
+
+resource "local_file" "common_configuration" {
+  for_each = toset(local.config_management_common_files)
+
+  file_permission = "0644"
+  filename        = "${local.config_management_common_files_destination_directory_path}/${each.value}"
+  source          = "${local.config_management_common_files_path}/${each.value}"
+}
+
+resource "local_file" "oci_descriptors_configuration" {
+  for_each = toset(local.config_management_oci_descriptors_files)
+
+  file_permission = "0644"
+  filename        = "${local.config_management_oci_descriptors_destination_directory_path}/${each.value}"
+  source          = "${local.config_management_oci_descriptors_path}/${each.value}"
+}
+
+resource "local_file" "namespace_configuration" {
+  for_each = {
+    for namespace_config in local.namespaces_configuration : namespace_config.destination_file_path => namespace_config
+  }
+
+  content = templatefile(
+    each.value.template_source_file_path,
+    each.value.template_variables
+  )
+  file_permission = "0644"
+  filename        = each.value.destination_file_path
+}
+
+resource "terraform_data" "config_management_oci_archive_push" {
+
+  provisioner "local-exec" {
+    command = local.push_container_image_script_path
+
+    environment = {
+      CONTAINER_IMAGE_BUILD_CONTEXT_PATH = local.config_management_destination_directory_path
+      CONTAINER_IMAGE_REPOSITORY_DOMAIN  = local.oci_repo_domain
+      CONTAINER_IMAGE_REPOSITORY_URL     = local.oci_repo_url
+      CONTAINER_IMAGE_DESTINATION_TAG    = local.oci_sync_repo_url
+    }
+  }
+
+  triggers_replace = [
+    # Trigger whenever the contents of source directories or template configuration values change.
+    # Don't depend on destination directory content because it might change between plan and apply.
+    sha512(join("", [for f in fileset(local.config_management_common_files_path, "**") : filesha512("${local.config_management_common_files_path}/${f}")])),
+    sha512(join("", [for f in fileset(local.config_management_oci_descriptors_path, "**") : filesha512("${local.config_management_oci_descriptors_path}/${f}")])),
+    sha512(join("", [for f in fileset(local.namespace_configuration_template_directory_path, "**") : filesha512("${local.namespace_configuration_template_directory_path}/${f}")])),
+    # Trigger whenever the namespace configuration changes
+    local.namespaces_configuration,
+    # Trigger whenever the contents of the container image push script changes
+    filesha512(local.push_container_image_script_path),
+    # Trigger whenever destination paths change
+    local.config_management_destination_directory_path,
+    local.config_management_common_files_destination_directory_path,
+    local.config_management_oci_descriptors_destination_directory_path,
+    local.namespace_configuration_destination_directory_path,
+    # Trigger whenever OCI container image repository coordinates change
+    local.oci_repo_domain,
+    local.oci_repo_url,
+    local.oci_sync_repo_url,
+  ]
+
+  # Wait for files to be there before attempting to build the OCI container image containing
+  # configuration files
+  depends_on = [
+    local_file.common_configuration,
+    local_file.oci_descriptors_configuration,
+    local_file.namespace_configuration,
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "cluster" {
+  project_id = var.cluster_project_id
+}
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/scripts/build-push-container-image.sh
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/scripts/build-push-container-image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+docker build \
+  --tag "${CONTAINER_IMAGE_DESTINATION_TAG}" \
+  "${CONTAINER_IMAGE_BUILD_CONTEXT_PATH}"
+
+gcloud auth configure-docker "${CONTAINER_IMAGE_REPOSITORY_DOMAIN}"
+
+docker push "${CONTAINER_IMAGE_DESTINATION_TAG}"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/mutations.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/mutations.yaml
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PolicyController mutations.
+# https://cloud.google.com/anthos-config-management/docs/how-to/mutation#writing_mutators
+---
+# Adds a node affinity to all pods in a specific namespace
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: mutator-add-nodeaffinity-${namespace_name}
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+  match:
+    namespaces:
+      - "${namespace_name}"
+  location: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms"
+  parameters:
+    assign:
+      value:
+        - matchExpressions:
+            - key: "tenant"
+              operator: In
+              values:
+                - "${namespace_name}"
+---
+# Adds a toleration to all pods in a specific namespace so they can be deployed
+# on nodes that belong to this tenant.
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: mutator-add-toleration-${namespace_name}
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+  match:
+    namespaces:
+      - "${namespace_name}"
+  location: "spec.tolerations"
+  parameters:
+    assign:
+      value:
+        - key: "tenant"
+          operator: "Equal"
+          value: "${namespace_name}"
+          effect: "NoExecute"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/namespace.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/namespace.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace_name}
+  labels:
+    tenant-ns: "true"
+    # Allow Cloud Service Mesh to manage the workloads in the namespace
+    # Ref: https://cloud.google.com/service-mesh/docs/managed/select-a-release-channel#injection_labels
+    istio.io/rev: asm-managed

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/network-policy.yaml
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/templates/namespace_configuration/network-policy.yaml
@@ -1,0 +1,134 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny-all
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-within-own-namespace
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ${namespace_name}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ${namespace_name}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-metadata-server
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock: # For GKE dataplane v2
+            cidr: 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 80
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.252/32
+        - ipBlock:
+            cidr: 127.0.0.1/32
+      ports:
+        - protocol: TCP
+          port: 988
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-istio-system
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-istio-egress
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-kube-system-dns
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-egress-to-private-google-apis
+  namespace: ${namespace_name}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 199.36.153.8/30

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/versions.tf
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.2"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_policy_controller_deploy-v1"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.12.0"
+  constraints = "6.12.0"
+  hashes = [
+    "h1:rvZHMkoxkHrBYQXb/waoZiD2oo3FS1AF8HoWHlb6SN8=",
+    "zh:14701aa307a832d99f567b8056a4c5e4ee5a403d984c98f024deee7507a3f29c",
+    "zh:344eca00ffb2643c2fa7f52f069b659d50bb4c9369df4cad96ea0fadb54282c8",
+    "zh:5fb57c0acfd4d30a39941900040d5518a909d8c975af0c4366a7bfd0d0bb09a8",
+    "zh:617a77048a5b9aa568e8bc706cc84307a237b2dd0e49709028b283f8bbe42475",
+    "zh:677837a05fefe0342cf4d4bdc494e8fd4d62331cac947820e73df37e8f512688",
+    "zh:7b79f6e02474eef4a1480fc6589afb63ed16b25bf019b6056f9838e2845e2ef8",
+    "zh:7d891fceb5b15e81240d829f42e1a36e4c812bfc1abe7856756e59101932205f",
+    "zh:97f1e0ac799faf382426e070e888fac36b0867597b460dc95b0e7f657de21ba9",
+    "zh:9855f2f2f5919ff6a6a2c982439c910d28c8978ad18cd8f549a5d1ba9b4dc4c3",
+    "zh:ac551367180eb396af2a50244e80243d333d600a76002e29935262d76a02290b",
+    "zh:c354f34e6579933d21a98ce7f31f4ef8aeaceb04cfaedaff6d3f3c0be56b2c79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning.auto.tfvars
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/_uc_federated_learning_variables.tf
@@ -1,0 +1,1 @@
+../_shared_config/uc_federated_learning_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_container_cluster" "cluster" {
+  location = var.cluster_region
+  name     = local.cluster_name
+  project  = data.google_project.default.project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
@@ -1,0 +1,79 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_container_node_pool" "fl_container_node_pool" {
+  for_each = local.tenants
+
+  cluster            = data.google_container_cluster.cluster.name
+  initial_node_count = 1
+  location           = var.cluster_region
+  name               = each.value.tenant_nodepool_name
+  project            = data.google_project.default.project_id
+
+  autoscaling {
+    location_policy      = "BALANCED"
+    total_max_node_count = 32
+    total_min_node_count = 1
+  }
+
+  network_config {
+    enable_private_nodes = true
+  }
+
+  node_config {
+    enable_confidential_storage = var.cluster_confidential_nodes_enabled
+    machine_type                = var.federated_learning_node_pool_machine_type
+    service_account             = each.value.tenant_nodepool_sa_email
+
+    labels = {
+      "federated-learning-tenant" : each.value.tenant_name
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    confidential_nodes {
+      enabled = var.cluster_confidential_nodes_enabled
+    }
+
+    gcfs_config {
+      enabled = true
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+
+    taint {
+      effect = "NO_EXECUTE"
+      key    = "federated-learning-tenant"
+      value  = each.value.tenant_name
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      initial_node_count,
+      node_config[0].labels,
+      node_config[0].taint,
+    ]
+  }
+
+  timeouts {
+    create = "30m"
+    update = "20m"
+  }
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "default" {
+  project_id = var.cluster_project_id
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.12.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_container_node_pool_deploy-v1"
+  }
+}


### PR DESCRIPTION
Configure node pools for the federated learning use case.

Each "tenant" (a dedicated, isolated runtime environment) gets a node pool that can run only their workloads. Each node pool has a taint that matches the name of the tenant in order to repel pods belonging to other tenants.