### PR TITLE
fix: improve fine tuning image build time

### DIFF
--- a/.github/workflows/dictionary/google-cloud.txt
+++ b/.github/workflows/dictionary/google-cloud.txt
@@ -50,6 +50,7 @@ gsutil
 gvnic
 hdml
 heatmaps
+highcpu
 highgpu
 httproute
 hyperdiskml

--- a/use-cases/model-fine-tuning-pipeline/fine-tuning/pytorch/src/cloudbuild.yaml
+++ b/use-cases/model-fine-tuning-pipeline/fine-tuning/pytorch/src/cloudbuild.yaml
@@ -2,11 +2,12 @@ images:
   - ${_DESTINATION}
 options:
   logging: CLOUD_LOGGING_ONLY
+  machineType: "E2_HIGHCPU_8"
 serviceAccount:
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - build
-  - -t
-  - ${_DESTINATION}
-  - .
+  - name: 'docker:28.0.4"'
+    args:
+      - build
+      - -t
+      - ${_DESTINATION}
+      - .


### PR DESCRIPTION
Bring the fine tuning container image build time down from ~19:30 to ~8:40 by doing the following:

- Update the builder to the latest available docker version (28.0.4)
- Use a more powerful builder machine (E2_HIGHCPU_8)