### PR TITLE
feat: conditional node pools init

### DIFF
--- a/platforms/gke/base/_shared_config/initialize_variables.tf
+++ b/platforms/gke/base/_shared_config/initialize_variables.tf
@@ -22,3 +22,21 @@ variable "initialize_backend_use_case_name" {
   description = "Create a templated backend.tf file in each folder that contains a versions.tf file for the specified use case. This value should be a folder or path within the 'base/use-cases' directory."
   type        = string
 }
+
+variable "initialize_container_node_pools_cpu" {
+  default     = true
+  description = "Set to true to prepare the files to provision CPU-based node pools in the cluster region"
+  type        = bool
+}
+
+variable "initialize_container_node_pools_gpu" {
+  default     = true
+  description = "Set to true to prepare the files to provision GPU-based node pools in the cluster region"
+  type        = bool
+}
+
+variable "initialize_container_node_pools_tpu" {
+  default     = true
+  description = "Set to true to prepare the files to provision TPU-based node pools in the cluster region"
+  type        = bool
+}

--- a/platforms/gke/base/core/container_node_pool/container_node_pool_cpu_n4.tf
+++ b/platforms/gke/base/core/container_node_pool/container_node_pool_cpu_n4.tf
@@ -1,1 +1,0 @@
-cpu/region/us-central1/container_node_pool_cpu_n4.tf

--- a/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_a100.tf
+++ b/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_a100.tf
@@ -1,1 +1,0 @@
-gpu/region/us-central1/container_node_pool_gpu_a100.tf

--- a/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_h100.tf
+++ b/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_h100.tf
@@ -1,1 +1,0 @@
-gpu/region/us-central1/container_node_pool_gpu_h100.tf

--- a/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_l4.tf
+++ b/platforms/gke/base/core/container_node_pool/container_node_pool_gpu_l4.tf
@@ -1,1 +1,0 @@
-gpu/region/us-central1/container_node_pool_gpu_l4.tf

--- a/platforms/gke/base/core/container_node_pool/container_node_pool_tpu.tf
+++ b/platforms/gke/base/core/container_node_pool/container_node_pool_tpu.tf
@@ -1,1 +1,0 @@
-tpu/region/us-central1/container_node_pool_tpu.tf

--- a/platforms/gke/base/core/teardown.sh
+++ b/platforms/gke/base/core/teardown.sh
@@ -83,7 +83,6 @@ for terraservice in "${terraservices[@]}"; do
       "${ACP_PLATFORM_CORE_DIR}/networking/.terraform/" \
       "${ACP_PLATFORM_CORE_DIR}/container_cluster/.terraform/" \
       "${ACP_PLATFORM_CORE_DIR}/container_node_pool/.terraform/" \
-      "${ACP_PLATFORM_CORE_DIR}/container_node_pool"/container_node_pool_*.tf \
       "${ACP_PLATFORM_CORE_DIR}/gke_enterprise/configmanagement/git/.terraform/" \
       "${ACP_PLATFORM_CORE_DIR}/gke_enterprise/configmanagement/oci/.terraform/" \
       "${ACP_PLATFORM_CORE_DIR}/gke_enterprise/fleet_membership/.terraform/" \
@@ -93,8 +92,7 @@ for terraservice in "${terraservices[@]}"; do
       "${ACP_PLATFORM_CORE_DIR}/workloads/manifests"
 
     git restore \
-      "${ACP_PLATFORM_CORE_DIR}/initialize/backend.tf.bucket" \
-      "${ACP_PLATFORM_CORE_DIR}/container_node_pool"/container_node_pool_*.tf
+      "${ACP_PLATFORM_CORE_DIR}/initialize/backend.tf.bucket"
   fi
 done
 


### PR DESCRIPTION
- Introduce three new `initialize_container_node_pools_XXXX` variables in the `initialize` service to support skipping the initialization of Terraform files in the `container_node_pool` service. This allows users to skip the initialization of unneeded node pools.
- Refactor the implementation of the resources that initialize Terraform files in the `container_node_pool` service using a `file` resource, instead of an always-triggering `null_resource` that created symbolic links. This has the following benefits:
  - Avoid unnecessary diffs when running Terraform apply
  - Create resources only when needed, instead of triggering the deletion and creation of symlinks on each Terraform run
  - Manage files with Terraform-native resources
- Remove the existing symlinks to the node pools Terraform files in the `container_node_pool` service because the `initialize` service takes care of initializing these files if needed.