### PR TITLE
fix: update terraform required version

### DIFF
--- a/platforms/gke/base/core/README.md
+++ b/platforms/gke/base/core/README.md
@@ -80,6 +80,10 @@ terraform_project_id = "<PROJECT_ID>"
 
 ## Deploy
 
+To deploy this reference implementation, you need Terraform >= 1.8.0. For more
+information about installing Terraform, see
+[Install Terraform](https://developer.hashicorp.com/terraform/install).
+
 ```shell
 ${ACP_PLATFORM_CORE_DIR}/deploy.sh
 ```

--- a/platforms/gke/base/modules/kubectl_apply/versions.tf
+++ b/platforms/gke/base/modules/kubectl_apply/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.7"
+  required_version = ">= 1.8.0"
 
   required_providers {
     local = {

--- a/platforms/gke/base/use-cases/federated-learning/README.md
+++ b/platforms/gke/base/use-cases/federated-learning/README.md
@@ -166,68 +166,70 @@ controls to each Kubernetes namespace:
 
 To deploy the reference architecture, you do the following:
 
-1.  Open [Cloud Shell](https://cloud.google.com/shell).
+1. [Install Terraform >= 1.8.0](https://developer.hashicorp.com/terraform/install).
 
-1.  Clone this repository and change the working directory:
+1. Open [Cloud Shell](https://cloud.google.com/shell).
 
-    ```shell
-    git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
-    cd accelerated-platforms
-    ```
+1. Clone this repository and change the working directory:
 
-1.  Configure the ID of the Google Cloud project where you want to initialize
-    the provisioning and configuration environment. This project will also
-    contain the remote Terraform backend. Add the following content to
-    `platforms/gke/base/_shared_config/terraform.auto.tfvars`:
+   ```shell
+   git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
+   cd accelerated-platforms
+   ```
 
-    ```hcl
-    terraform_project_id = "<CONFIG_PROJECT_ID>"
-    ```
+1. Configure the ID of the Google Cloud project where you want to initialize the
+   provisioning and configuration environment. This project will also contain
+   the remote Terraform backend. Add the following content to
+   `platforms/gke/base/_shared_config/terraform.auto.tfvars`:
 
-    Where:
+   ```hcl
+   terraform_project_id = "<CONFIG_PROJECT_ID>"
+   ```
 
-    - `<CONFIG_PROJECT_ID>` is the Google Cloud project ID.
+   Where:
 
-1.  Configure the ID of the Google Cloud project where you want to deploy the
-    reference architecture by adding the following content to
-    `platforms/gke/base/_shared_config/cluster.auto.tfvars`:
+   - `<CONFIG_PROJECT_ID>` is the Google Cloud project ID.
 
-    ```hcl
-    cluster_project_id = "<PROJECT_ID>"
-    ```
+1. Configure the ID of the Google Cloud project where you want to deploy the
+   reference architecture by adding the following content to
+   `platforms/gke/base/_shared_config/cluster.auto.tfvars`:
 
-    Where:
+   ```hcl
+   cluster_project_id = "<PROJECT_ID>"
+   ```
 
-    - `<PROJECT_ID>` is the Google Cloud project ID. Can be different from
-      `<CONFIG_PROJECT_ID>`.
+   Where:
 
-1.  Optionally configure a unique identifier to append to the name of all the
-    resources in the reference architecture to identify a particular instance of
-    the reference architecture, and to allow for multiple instances of the
-    reference architecture to be deployed in the same Google Cloud project. To
-    optionally configure the unique prefix, add the following content to
-    `platforms/gke/base/_shared_config/platform.auto.tfvars`:
+   - `<PROJECT_ID>` is the Google Cloud project ID. Can be different from
+     `<CONFIG_PROJECT_ID>`.
 
-    ```hcl
-    resource_name_prefix = "<RESOURCE_NAME_PREFIX>"
-    platform_name        = "<PLATFORM_NAME>"
-    ```
+1. Optionally configure a unique identifier to append to the name of all the
+   resources in the reference architecture to identify a particular instance of
+   the reference architecture, and to allow for multiple instances of the
+   reference architecture to be deployed in the same Google Cloud project. To
+   optionally configure the unique prefix, add the following content to
+   `platforms/gke/base/_shared_config/platform.auto.tfvars`:
 
-    Where:
+   ```hcl
+   resource_name_prefix = "<RESOURCE_NAME_PREFIX>"
+   platform_name        = "<PLATFORM_NAME>"
+   ```
 
-    - `<RESOURCE_NAME_PREFIX>` and `<PLATFORM_NAME>` are strings that compose
-      the unique identifier to append to the name of all the resources in the
-      reference architecture.
+   Where:
 
-    When you set `resource_name_prefix` and `platform_name`, we recommend that
-    you avoid long strings because the might make resource naming validation to
-    fail because the resource name might be too long.
+   - `<RESOURCE_NAME_PREFIX>` and `<PLATFORM_NAME>` are strings that compose the
+     unique identifier to append to the name of all the resources in the
+     reference architecture.
 
-1.  Run the script to provision the reference architecture:
+   When you set `resource_name_prefix` and `platform_name`, we recommend that
+   you avoid long strings because the might make resource naming validation to
+   fail because the resource name might be too long.
 
-    ```sh
-    "platforms/gke/base/use-cases/federated-learning/deploy.sh"
-    ```
+1. Run the script to provision the reference architecture:
+
+   ```sh
+   "platforms/gke/base/use-cases/federated-learning/deploy.sh"
+   ```
 
 It takes about 20 minutes to provision the reference architecture.
 

--- a/test/ci-cd/container_images/dockerfile.runner
+++ b/test/ci-cd/container_images/dockerfile.runner
@@ -3,22 +3,25 @@ ARG GCLOUD_VERSION="504.0.1"
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:${GCLOUD_VERSION}-alpine
 
 ARG CRANE_VERSION="v0.20.2"
-ARG TERRAFORM_VERSION="1.9.7"
+# When updating the Terraform version, ensure that you also updated the
+# required_version in Terraform modules and services across the repository.
+# Also, consider what Terraform version Cloud Shell ships.
+ARG TERRAFORM_VERSION="1.8.0"
 
 RUN echo "Installing Alpine packages" && \
-apk upgrade && \
-apk --no-cache add go ncurses && \
-echo "Installing Terraform v${TERRAFORM_VERSION}" && \
-cd /usr/local/bin && \
-curl -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-unzip terraform.zip && \
-chmod u+x terraform && \
-rm -f LICENSE.txt terraform.zip && \
-echo "Installing gcloud components" && \
-gcloud components install beta kubectl --quiet && \
-rm -rf $(find /google-cloud-sdk/ -regex ".*/__pycache__") && \
-rm -rf /google-cloud-sdk/.install/.backup && \
-echo "Installing crane" && \
-go install github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}
+  apk upgrade && \
+  apk --no-cache add go ncurses && \
+  echo "Installing Terraform v${TERRAFORM_VERSION}" && \
+  cd /usr/local/bin && \
+  curl -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+  unzip terraform.zip && \
+  chmod u+x terraform && \
+  rm -f LICENSE.txt terraform.zip && \
+  echo "Installing gcloud components" && \
+  gcloud components install beta kubectl --quiet && \
+  rm -rf $(find /google-cloud-sdk/ -regex ".*/__pycache__") && \
+  rm -rf /google-cloud-sdk/.install/.backup && \
+  echo "Installing crane" && \
+  go install github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}
 
 ENV PATH="${PATH}:/root/go/bin"


### PR DESCRIPTION
Update Terraform required_version to 1.8.0 because it uses Terraform
provider functions, only available since >1.8.0.

Also, added docs to instruct users about the needed Terraform version.