### PR TITLE
Added initialize Terraservice to Federated Learning

### DIFF
--- a/platforms/gke/base/use-cases/federated-learning/common.sh
+++ b/platforms/gke/base/use-cases/federated-learning/common.sh
@@ -61,6 +61,7 @@ federated_learning_core_platform_terraservices=(
 
 # shellcheck disable=SC2034 # Variable is used in other scripts
 federated_learning_terraservices=(
+  "initialize"
   "firewall"
   "container_image_repository"
   "private_google_access"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = "6.29.0"
+  hashes = [
+    "h1:E+nXAl8krGxH+AtEYiyNannu+Viv1aoft1U0V/ZCSso=",
+    "zh:01a501df2fb9ecbf0935b27e588bc7b6bcaf4ab0043747f4229c25e4ba47dadb",
+    "zh:056f8ab2b73755cf5a67228ab4a07882e76265fa25b07f2794d9939288164f48",
+    "zh:0dbdfa564f7db8a2e6f7e76437a9850b6101450120c08e87cf9846330736c0c6",
+    "zh:3c3e4ee801de22812bd07cb3d36b227f8057d7825998fb4d97051764a565b89b",
+    "zh:4e440eb4c60da9cd7d23b3b99be54c869472fd70006c39639a04b9a51248929c",
+    "zh:659490efd20b3e98e4166b2925baa18549d82e4c16751bc92baed0185d22d108",
+    "zh:9ae24b98a3a3346b8004c6b87e3b59decba2f64c7407e106263859c275105ef8",
+    "zh:c64cff9c17e302236bb9e0a6d5eff4c92540ce3947269f3db94e2b9a1b1a3f4e",
+    "zh:d2fd0aecbbbba463bcb0640f54c8df5e7a63918bdd44236dcd36dff33bb8de09",
+    "zh:f022316369ea676f5f9d11768b4c621abd3304c1e6d1f0c2361e4e2620c4b65d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:feb7d4fdbebdfabac2aaa73376f754736ccf089fa90adf6388701f89801188e6",
+  ]
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_cluster.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_cluster.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_cluster_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_cluster_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/cluster_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform.auto.tfvars

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../../_shared_config/platform_variables.tf

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/project.tf
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "cluster" {
+  project_id = var.cluster_project_id
+}
+
+resource "google_project_service" "cluster_cloudkms_googleapis_com" {
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = data.google_project.cluster.project_id
+  service                    = "cloudkms.googleapis.com"
+}

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/versions.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.29.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_fl_initialize_deploy-v1"
+  }
+}


### PR DESCRIPTION
Added `cloudkms.googleapis.com` service to initialize Terraservice to avoid sporadic failures due to a race condition for enabling the service.