### PR TITLE
feat: deploy llama3-70B

### DIFF
--- a/platforms/gke/base/core/custom_compute_class/main.tf
+++ b/platforms/gke/base/core/custom_compute_class/main.tf
@@ -16,9 +16,12 @@ locals {
   kubeconfig_directory = "${path.module}/../../kubernetes/kubeconfig"
   kubeconfig_file      = "${local.kubeconfig_directory}/${local.kubeconfig_file_name}"
 
-  manifests_directory          = "${local.manifests_directory_root}/cluster/ccc"
-  manifests_directory_root     = "${path.module}/../../kubernetes/manifests"
-  template_manifests_directory = "${path.module}/manifests/ccc"
+  manifests_directory                 = "${local.manifests_directory_root}/cluster/ccc"
+  manifests_directory_root            = "${path.module}/../../kubernetes/manifests"
+  template_manifests_directory        = "${path.module}/manifests/ccc"
+  template_manifests_source_directory = "${path.module}/templates/manifests"
+
+  template_manifests_source_directory_contents_hash = sha512(join("", [for f in fileset(local.template_manifests_source_directory, "**") : filesha512("${local.template_manifests_source_directory}/${f}")]))
 }
 
 data "local_file" "kubeconfig" {
@@ -27,15 +30,16 @@ data "local_file" "kubeconfig" {
 
 resource "terraform_data" "manifests" {
   input = {
-    manifests_directory          = local.manifests_directory
-    template_manifests_directory = local.template_manifests_directory
+    manifests_directory                 = local.manifests_directory
+    template_manifests_directory        = local.template_manifests_directory
+    template_manifests_source_directory = local.template_manifests_source_directory
   }
 
   provisioner "local-exec" {
     command     = <<EOT
 mkdir -p "${self.input.template_manifests_directory}" && \
 mkdir -p "${self.input.manifests_directory}" && \
-cp -r templates/manifests/* "${self.input.template_manifests_directory}/" && \
+cp -r "${self.input.template_manifests_source_directory}"/* "${self.input.template_manifests_directory}/" && \
 cp -r "${self.input.template_manifests_directory}"/* "${self.input.manifests_directory}/"
 EOT
     interpreter = ["bash", "-c"]
@@ -45,6 +49,10 @@ EOT
   triggers_replace = {
     manifests_directory          = local.manifests_directory
     template_manifests_directory = local.template_manifests_directory
+
+    # Trigger whenever the contents of source directories change.
+    # Don't depend on destination directory content because it might change between plan and apply.
+    template_manifests_source_directory_contents_hash = local.template_manifests_source_directory_contents_hash,
   }
 }
 
@@ -55,11 +63,13 @@ module "kubectl_apply_manifests" {
 
   source = "../../modules/kubectl_apply"
 
+  apply_once                  = false
   apply_server_side           = true
   kubeconfig_file             = data.local_file.kubeconfig.filename
   manifest                    = local.template_manifests_directory
   manifest_includes_namespace = true
   recursive                   = true
+  source_content_hash         = local.template_manifests_source_directory_contents_hash
   use_kustomize               = false
 }
 

--- a/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/h100-80gb/custom-compute-gpu-h100-80gb-x4-high.yaml
+++ b/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/h100-80gb/custom-compute-gpu-h100-80gb-x4-high.yaml
@@ -1,0 +1,42 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: gpu-h100-80gb-x4-high
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  priorities:
+    # Use reservations if available, fall back to on-demand otherwise
+    - gpu:
+        count: 4
+        driverVersion: latest
+        type: nvidia-h100-80gb
+      machineType: a3-highgpu-4g
+      maxPodsPerNode: 16
+      reservations:
+        affinity: AnyBestEffort
+      spot: false
+
+    # Use DWS FlexStart
+    # - flexStart:
+    #     enabled: true
+    #     nodeRecycling:
+    #       leadTimeSeconds: 3600
+    #   gpu:
+    #     count: 4
+    #     driverVersion: latest
+    #     type: nvidia-h100-80gb
+    #   machineType: a3-highgpu-4g
+    #   maxPodsPerNode: 16
+
+    # Use spot
+    - gpu:
+        count: 4
+        driverVersion: latest
+        type: nvidia-h100-80gb
+      machineType: a3-highgpu-4g
+      maxPodsPerNode: 16
+      spot: true
+
+  nodePoolAutoCreation:
+    enabled: true

--- a/platforms/gke/base/modules/kubectl_apply/main.tf
+++ b/platforms/gke/base/modules/kubectl_apply/main.tf
@@ -60,5 +60,6 @@ resource "terraform_data" "manifest" {
     kubectl_apply_command  = local.kubectl_apply_command
     kubectl_delete_command = local.kubectl_delete_command
     manifest_md5           = var.apply_once ? "" : local.manifest_is_directory ? md5(join("", [for f in fileset(var.manifest, "**") : md5("${var.manifest}/${f}")])) : md5(var.manifest)
+    source_content_hash    = var.apply_once ? "" : var.source_content_hash
   }
 }

--- a/platforms/gke/base/modules/kubectl_apply/variables.tf
+++ b/platforms/gke/base/modules/kubectl_apply/variables.tf
@@ -64,6 +64,12 @@ variable "recursive" {
   type        = bool
 }
 
+variable "source_content_hash" {
+  default     = ""
+  description = "Hash of the contents of the source files. Can be used to trigger a new kubectl apply whenever the source contents change."
+  type        = string
+}
+
 variable "use_kustomize" {
   default     = false
   description = "Does the manifest use kustomize."

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/load-model-to-cloud-storage.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/load-model-to-cloud-storage.yaml
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: transfer-model-to-gcs
+spec:
+  storageClassName: premium-rwo
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,9 +41,11 @@ spec:
         gke-gcsfuse/memory-limit: "0"
         gke-gcsfuse/ephemeral-storage-limit: "0"
     spec:
+      securityContext:
+        fsGroup: 10000
       nodeSelector:
         iam.gke.io/gke-metadata-server-enabled: "true"
-      restartPolicy: Never
+      restartPolicy: OnFailure
       terminationGracePeriodSeconds: 0
       serviceAccountName: ira-model-download-ksa
       containers:
@@ -61,7 +75,7 @@ spec:
               echo "Downloading ${MODEL_ID} to ${IRA_BUCKET_NAME} Cloud Storage bucket"
               echo "Debug Hugging Face token length: ${#HUGGING_FACE_TOKEN}"
 
-              pip3 install -U "huggingface_hub[cli]==0.30.2" --break-system-packages
+              pip3 install -U "huggingface_hub[cli]==0.31.4" --break-system-packages
 
               huggingface-cli download --repo-type model ${MODEL_ID} --local-dir /local/temp --token ${HUGGING_FACE_TOKEN}
 
@@ -89,10 +103,10 @@ spec:
           # package, at the expense of download speed.
           resources:
             limits:
-              cpu: 2000m
+              cpu: 4000m
               memory: 8Gi
             requests:
-              cpu: 2000m
+              cpu: 4000m
               memory: 8Gi
           volumeMounts:
             - name: gcsfuse
@@ -106,6 +120,9 @@ spec:
             driver: gcsfuse.csi.storage.gke.io
             volumeAttributes:
               bucketName: cloud-storage-bucket-name
+        - name: gke-gcsfuse-buffer
+          persistentVolumeClaim:
+            claimName: transfer-model-to-gcs
       tolerations:
         - key: "on-demand"
           value: "true"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/kustomization.yaml
@@ -1,0 +1,62 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../online-inference-gpu-base
+
+nameSuffix: -llama3
+
+patches:
+  - path: set-h100-80gb-high-compute-class.yaml
+  - path: set-vllm-llama3-resources-limits.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: ira-model-configmap
+      fieldPath: data.IRA_BUCKET_NAME
+    targets:
+      - select:
+          kind: Deployment
+          name: vllm
+        fieldPaths:
+          - spec.template.spec.volumes.[name=gcsfuse].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+  - source:
+      kind: ConfigMap
+      name: ira-model-configmap
+      fieldPath: data.MODEL_ID
+    targets:
+      - select:
+          kind: Deployment
+          name: vllm
+        fieldPaths:
+          - spec.template.spec.volumes.[name=gcsfuse].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+      - select:
+          kind: Deployment
+          name: vllm
+        fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=gcsfuse].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=gcsfuse].mountPath
+        options:
+          delimiter: "/"
+          index: 2

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/set-h100-80gb-high-compute-class.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/set-h100-80gb-high-compute-class.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-h100-80gb-x4-high

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/set-vllm-llama3-resources-limits.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu-h100-llama3/set-vllm-llama3-resources-limits.yaml
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            requests:
+              cpu: "64"
+              memory: "512G"
+              nvidia.com/gpu: "4"
+            limits:
+              cpu: "64"
+              memory: "512G"
+              nvidia.com/gpu: "4"

--- a/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/README.md
@@ -84,7 +84,7 @@ the following:
         `google/gemma-3-27b-it`
       - For Llama 4, the fully qualified model identifier is:
         `meta-llama/Llama-4-Scout-17B-16E-Instruct`
-      - For Llama 3.3, the fully qualified model identifier is:
+      - For Llama 3.3 70B, the fully qualified model identifier is:
         `meta-llama/Llama-3.3-70B-Instruct`
 
     - `<TENSOR_PARALLEL_SIZE>` is the number of GPUs necessary to run the model.
@@ -95,7 +95,7 @@ the following:
 
         - NVIDIA H100: at least 1
 
-      - For Llama 3.3:
+      - For Llama 3.3 70B:
 
         - NVIDIA H100: at least 4
 
@@ -105,6 +105,10 @@ the following:
 
     - `<MAX_MODEL_LEN>` is the maximum context length. For more information, see
       [vLLM Engine arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html).
+
+      - For Llama 3.3 70B:
+
+        - NVIDIA H100: `131072`
 
       - For Llama 4 Scout:
 
@@ -171,6 +175,17 @@ the following:
     kubectl delete job transfer-model-to-gcs
     ```
 
+    Note: the model downloader job has `ttlSecondsAfterFinished` configured, so
+    the command to delete it might return an error if you wait for more than
+    `ttlSecondsAfterFinished` seconds after the job completes because GKE
+    automatically deletes it to reclaim resources.
+
+1.  Delete the model downloader cache PersistentVolumeClaim:
+
+    ```shell
+    kubectl delete pvc transfer-model-to-gcs
+    ```
+
 ## Deploy the online inference workload
 
 1.  Deploy the online inference workload in the GKE cluster:
@@ -187,6 +202,7 @@ the following:
 
     - `MODEL_NAME` is the name of the model to deploy. Valid values are:
 
+      - `llama3`
       - `llama4-scout`
 
     Ensure that you have enough quota in your project to provision the selected

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/initialize/local_files.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/initialize/local_files.tf
@@ -31,6 +31,11 @@ resource "local_file" "cloud_storage_terraform_configuration_file" {
   ira_cloud_storage_buckets_iam_bindings = [
     {
       bucket_name = "ira-model",
+      member      = "${var.ira_kubernetes_namespace}/sa/ira-online-gpu-ksa-llama3",
+      role        = "roles/storage.objectViewer"
+    },
+    {
+      bucket_name = "ira-model",
       member      = "${var.ira_kubernetes_namespace}/sa/ira-online-gpu-ksa-llama4-scout",
       role        = "roles/storage.objectViewer"
     },


### PR DESCRIPTION
- Deploy llama3-70b on the inference reference architecture
- Fix an issue with the `custom_compute_class` service not picking up changes in manifest contents.
- Support triggering the `kubectl_apply` service when contents of kubernetes manifests change