### PR TITLE
Added default project ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,16 @@ test/scripts/environment_files/*
 node_modules
 
 gke_gcloud_auth_plugin_cache
+
+# Development
+# **/backend.tf
+# platforms/gke/base/core/container_node_pool/container_node_pool_*
+# platforms/gke/base/core/custom_compute_class/manifests/*
+# platforms/gke/base/core/workloads/custom_metrics_adapter/manifests/*
+# platforms/gke/base/core/workloads/inference_gateway/manifests/*
+# platforms/gke/base/core/workloads/jobset/manifests/*
+# platforms/gke/base/core/workloads/kueue/manifests/*
+# platforms/gke/base/core/workloads/lws/manifests/*
+# platforms/gke/base/core/workloads/nvidia_nim/*
+# platforms/gke/base/core/workloads/priority_class/manifests/*
+# platforms/gke/base/kubernetes/*

--- a/platforms/gke/base/_shared_config/cluster_variables.tf
+++ b/platforms/gke/base/_shared_config/cluster_variables.tf
@@ -18,8 +18,8 @@
 #
 
 locals {
-  cluster_credentials_command_gke  = "gcloud container clusters get-credentials ${local.cluster_name} --dns-endpoint --location ${var.cluster_region} --project ${var.cluster_project_id}"
-  cluster_credentials_command_gkee = "gcloud container fleet memberships get-credentials ${local.cluster_name} --project ${var.cluster_project_id}"
+  cluster_credentials_command_gke  = "gcloud container clusters get-credentials ${local.cluster_name} --dns-endpoint --location ${var.cluster_region} --project ${local.cluster_project_id}"
+  cluster_credentials_command_gkee = "gcloud container fleet memberships get-credentials ${local.cluster_name} --project ${local.cluster_project_id}"
   cluster_credentials_command      = var.cluster_use_connect_gateway ? local.cluster_credentials_command_gkee : local.cluster_credentials_command_gke
 
   cluster_name = local.unique_identifier_prefix
@@ -27,7 +27,9 @@ locals {
   cluster_node_auto_provisioning_resource_limits = var.cluster_node_auto_provisioning_enabled ? var.cluster_node_auto_provisioning_resource_limits : []
 
   cluster_node_pool_service_account_id         = var.cluster_node_pool_default_service_account_id != null ? var.cluster_node_pool_default_service_account_id : "vm-${local.cluster_name}"
-  cluster_node_pool_service_account_project_id = var.cluster_node_pool_default_service_account_project_id != null ? var.cluster_node_pool_default_service_account_project_id : var.cluster_project_id
+  cluster_node_pool_service_account_project_id = var.cluster_node_pool_default_service_account_project_id != null ? var.cluster_node_pool_default_service_account_project_id : local.cluster_project_id
+
+  cluster_project_id = var.cluster_project_id != null ? var.cluster_project_id : var.platform_default_project_id
 
   # Minimal roles for nodepool SA https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
   cluster_sa_roles = [
@@ -40,7 +42,7 @@ locals {
     "roles/stackdriver.resourceMetadata.writer",
   ]
 
-  kubeconfig_file_name = "${var.cluster_project_id}-${local.cluster_name}"
+  kubeconfig_file_name = "${local.cluster_project_id}-${local.cluster_name}"
 }
 
 variable "cluster_auto_monitoring_config_scope" {
@@ -213,13 +215,9 @@ variable "cluster_private_endpoint_subnetwork" {
 }
 
 variable "cluster_project_id" {
+  default     = null
   description = "The GCP project where the cluster resources will be created"
   type        = string
-
-  validation {
-    condition     = var.cluster_project_id != ""
-    error_message = "'cluster_project_id' was not set, please set the value in the mlp.auto.tfvars file"
-  }
 }
 
 variable "cluster_region" {

--- a/platforms/gke/base/_shared_config/configmanagement_variables.tf
+++ b/platforms/gke/base/_shared_config/configmanagement_variables.tf
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# Configuration dependencies
+# - shared_config/cluster_variables.tf
+# - shared_config/platform_variables.tf
+#
+
 locals {
   config_management_kubernetes_namespace       = "config-management-system"
   config_management_kubernetes_service_account = "root-reconciler"
@@ -23,7 +29,7 @@ locals {
 
   oci_repo_id              = "${local.unique_identifier_prefix}-config-sync"
   oci_repo_domain          = "${var.cluster_region}-docker.pkg.dev"
-  oci_repo_url             = "${local.oci_repo_domain}/${var.cluster_project_id}/${local.oci_repo_id}"
+  oci_repo_url             = "${local.oci_repo_domain}/${local.cluster_project_id}/${local.oci_repo_id}"
   oci_root_sync_image      = "${local.oci_root_sync_image_name}:${local.oci_root_sync_image_tag}"
   oci_root_sync_image_name = "root-sync"
   oci_root_sync_image_tag  = "latest"

--- a/platforms/gke/base/_shared_config/initialize_variables.tf
+++ b/platforms/gke/base/_shared_config/initialize_variables.tf
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Configuration dependencies
-# - shared_config/platform_variables.tf
-#
-
 variable "initialize_backend_use_case_name" {
   default     = null
   description = "Create a templated backend.tf file in each folder that contains a versions.tf file for the specified use case. This value should be a folder or path within the 'base/use-cases' directory."

--- a/platforms/gke/base/_shared_config/outputs.tf
+++ b/platforms/gke/base/_shared_config/outputs.tf
@@ -17,7 +17,7 @@ output "cluster_name" {
 }
 
 output "cluster_project_id" {
-  value = var.cluster_project_id
+  value = local.cluster_project_id
 }
 
 output "cluster_region" {
@@ -33,7 +33,7 @@ output "terraform_bucket_name" {
 }
 
 output "terraform_project_id" {
-  value = var.terraform_project_id
+  value = local.terraform_project_id
 }
 
 output "resource_name_prefix" {

--- a/platforms/gke/base/_shared_config/platform_variables.tf
+++ b/platforms/gke/base/_shared_config/platform_variables.tf
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Configuration dependencies
-# - shared_config/platform_variables.tf
-#
-
 locals {
   unique_identifier_prefix = "${var.resource_name_prefix}-${var.platform_name}"
+}
+
+variable "platform_default_project_id" {
+  description = "The default project ID to use if a specific project ID is not specified"
+  type        = string
+
+  validation {
+    condition     = var.platform_default_project_id != ""
+    error_message = "'platform_default_project_id' was not set, please set the value in 'shared_config/platform.auto.tfvars' file or via the TF_VAR_platform_default_project_id"
+  }
 }
 
 variable "platform_name" {

--- a/platforms/gke/base/_shared_config/terraform_variables.tf
+++ b/platforms/gke/base/_shared_config/terraform_variables.tf
@@ -18,7 +18,8 @@
 #
 
 locals {
-  terraform_bucket_name = "${var.terraform_project_id}-${local.unique_identifier_prefix}-terraform"
+  terraform_project_id  = var.terraform_project_id != null ? var.terraform_project_id : var.platform_default_project_id
+  terraform_bucket_name = "${local.terraform_project_id}-${local.unique_identifier_prefix}-terraform"
 }
 
 variable "create_terraform_bucket" {
@@ -28,13 +29,9 @@ variable "create_terraform_bucket" {
 }
 
 variable "terraform_project_id" {
+  default     = null
   description = "The GCP project where terraform will be run"
   type        = string
-
-  validation {
-    condition     = var.terraform_project_id != ""
-    error_message = "'terraform_project_id' was not set, please set the value in 'shared_config/terraform.auto.tfvars' file or via the TF_VAR_terraform_project_id"
-  }
 }
 
 variable "terraform_write_tfvars" {

--- a/platforms/gke/base/_shared_config/workloads_variables.tf
+++ b/platforms/gke/base/_shared_config/workloads_variables.tf
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Configuration dependencies
-#
-
 locals {
   manifests_directory_root = "${path.module}/../../../kubernetes/manifests"
 }

--- a/platforms/gke/base/core/README.md
+++ b/platforms/gke/base/core/README.md
@@ -2,6 +2,12 @@
 
 ## Pull the source code
 
+- Open [Cloud Shell](https://cloud.google.com/shell).
+
+  To deploy this reference implementation, you need Terraform >= 1.8.0. For more
+  information about installing Terraform, see
+  [Install Terraform](https://developer.hashicorp.com/terraform/install).
+
 - Clone the repository and set the repository directory environment variable.
 
   ```
@@ -55,10 +61,6 @@ For more information about providing values for Terraform input variables, see
   ```
 
 ## Deploy
-
-To deploy this reference implementation, you need Terraform >= 1.8.0. For more
-information about installing Terraform, see
-[Install Terraform](https://developer.hashicorp.com/terraform/install).
 
 ```shell
 ${ACP_PLATFORM_CORE_DIR}/deploy.sh

--- a/platforms/gke/base/core/README.md
+++ b/platforms/gke/base/core/README.md
@@ -2,36 +2,28 @@
 
 ## Pull the source code
 
-1. Open [Cloud Shell](https://cloud.google.com/shell).
+- Clone the repository and set the repository directory environment variable.
 
-1. Clone the repository and change directory to the guide directory
+  ```
+  git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
+  cd accelerated-platforms && \
+  export ACP_REPO_DIR="$(pwd)"
+  ```
 
-   ```shell
-   git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
-   cd accelerated-platforms
-   ```
+  To set the `ACP_REPO_DIR` value for new shell instances, write the value to
+  your shell initialization file.
 
-1. Set environment variables
+  `bash`
 
-   ```shell
-   ACP_REPO_DIR="$(pwd)" && \
-   export ACP_REPO_DIR && \
-   echo "export ACP_REPO_DIR=${ACP_REPO_DIR}" >> ${HOME}/.bashrc
-   ```
+  ```
+  sed -n -i -e '/^export ACP_REPO_DIR=/!p' -i -e '$aexport ACP_REPO_DIR="'"${ACP_REPO_DIR}"'"' ${HOME}/.bashrc
+  ```
 
-   ```shell
-   cd "${ACP_REPO_DIR}/platforms/gke/base" && \
-   ACP_PLATFORM_BASE_DIR="$(pwd)" && \
-   export ACP_PLATFORM_BASE_DIR && \
-   echo "export ACP_PLATFORM_BASE_DIR=${ACP_PLATFORM_BASE_DIR}" >> ${HOME}/.bashrc
-   ```
+  `zsh`
 
-   ```shell
-   cd "${ACP_REPO_DIR}/platforms/gke/base/core" && \
-   ACP_PLATFORM_CORE_DIR="$(pwd)" && \
-   export ACP_PLATFORM_CORE_DIR && \
-   echo "export ACP_PLATFORM_CORE_DIR=${ACP_PLATFORM_CORE_DIR}" >> ${HOME}/.bashrc
-   ```
+  ```
+  sed -n -i -e '/^export ACP_REPO_DIR=/!p' -i -e '$aexport ACP_REPO_DIR="'"${ACP_REPO_DIR}"'"' ${HOME}/.zshrc
+  ```
 
 ## Configure the Core GKE Accelerated Platform
 
@@ -46,37 +38,21 @@ precedence over earlier ones:
 For more information about providing values for Terraform input variables, see
 [Terraform input variables](https://developer.hashicorp.com/terraform/language/values/variables).
 
-- Set the cluster project ID
+- Set the platform default project ID
 
-```shell
-export TF_VAR_cluster_project_id="<PROJECT_ID>"
-```
+  ```shell
+  export TF_VAR_platform_default_project_id="<PROJECT_ID>"
+  ```
 
-**-- OR --**
+  **-- OR --**
 
-```shell
-vi ${ACP_PLATFORM_BASE_DIR}/_shared_config/cluster.auto.tfvars
-```
+  ```shell
+  vi ${ACP_REPO_DIR}/platforms/gke/base/_shared_config/platform.auto.tfvars
+  ```
 
-```hcl
-cluster_project_id = "<PROJECT_ID>"
-```
-
-- Set the Terraform project ID
-
-```shell
-export TF_VAR_terraform_project_id="<PROJECT_ID>"
-```
-
-**-- OR --**
-
-```shell
-vi ${ACP_PLATFORM_BASE_DIR}/_shared_config/terraform.auto.tfvars
-```
-
-```hcl
-terraform_project_id = "<PROJECT_ID>"
-```
+  ```hcl
+  platform_default_project_id = "<PROJECT_ID>"
+  ```
 
 ## Deploy
 

--- a/platforms/gke/base/core/container_cluster/project.tf
+++ b/platforms/gke/base/core/container_cluster/project.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "cloudresourcemanager_googleapis_com" {

--- a/platforms/gke/base/core/container_node_pool/container_cluster.tf
+++ b/platforms/gke/base/core/container_node_pool/container_cluster.tf
@@ -17,5 +17,5 @@ data "google_container_cluster" "cluster" {
 
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/core/container_node_pool/cpu/region/us-central1/container_node_pool_cpu_n4.tf
+++ b/platforms/gke/base/core/container_node_pool/cpu/region/us-central1/container_node_pool_cpu_n4.tf
@@ -32,7 +32,7 @@ resource "google_container_node_pool" "cpu_n4s8" {
     "us-central1-c",
     "us-central1-f",
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -102,7 +102,7 @@ resource "google_container_node_pool" "cpu_n4s8_spot" {
     "us-central1-c",
     "us-central1-f",
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {

--- a/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_a100.tf
+++ b/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_a100.tf
@@ -32,7 +32,7 @@ resource "google_container_node_pool" "gpu_a100x2_a2h2" {
     "us-central1-c",
     "us-central1-f"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -119,7 +119,7 @@ resource "google_container_node_pool" "gpu_a100x2_a2h2_dws" {
     "us-central1-c",
     "us-central1-f"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -210,7 +210,7 @@ resource "google_container_node_pool" "gpu_a100x2_a2h2_res" {
     "us-central1-c",
     "us-central1-f"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -297,7 +297,7 @@ resource "google_container_node_pool" "gpu_a100x2_a2h2_spot" {
     "us-central1-c",
     "us-central1-f"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {

--- a/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_h100.tf
+++ b/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_h100.tf
@@ -30,7 +30,7 @@ resource "google_container_node_pool" "gpu_h100x8_a3h8" {
     "us-central1-a",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -118,7 +118,7 @@ resource "google_container_node_pool" "gpu_h100x8_a3h8_dws" {
     "us-central1-a",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -210,7 +210,7 @@ resource "google_container_node_pool" "gpu_h100x8_a3h8_res" {
     "us-central1-a",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {
@@ -298,7 +298,7 @@ resource "google_container_node_pool" "gpu_h100x8_a3h8_spot" {
     "us-central1-a",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {

--- a/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_l4.tf
+++ b/platforms/gke/base/core/container_node_pool/gpu/region/us-central1/container_node_pool_gpu_l4.tf
@@ -31,7 +31,7 @@ resource "google_container_node_pool" "gpu_l4x2_g2s24" {
     "us-central1-b",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   autoscaling {
     location_policy      = "ANY"
@@ -115,7 +115,7 @@ resource "google_container_node_pool" "gpu_l4x2_g2s24_dws" {
     "us-central1-b",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   autoscaling {
     location_policy      = "ANY"
@@ -203,7 +203,7 @@ resource "google_container_node_pool" "gpu_l4x2_g2s24_res" {
     "us-central1-b",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   autoscaling {
     location_policy      = "ANY"
@@ -287,7 +287,7 @@ resource "google_container_node_pool" "gpu_l4x2_g2s24_spot" {
     "us-central1-b",
     "us-central1-c"
   ]
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
 
   # Blocks
   autoscaling {

--- a/platforms/gke/base/core/container_node_pool/project.tf
+++ b/platforms/gke/base/core/container_node_pool/project.tf
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/core/container_node_pool/service_account.tf
+++ b/platforms/gke/base/core/container_node_pool/service_account.tf
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 data "google_service_account" "cluster" {
-  project    = data.google_project.default.project_id
+  project    = data.google_project.cluster.project_id
   account_id = "vm-${local.cluster_name}"
 }

--- a/platforms/gke/base/core/custom_compute_class/project.tf
+++ b/platforms/gke/base/core/custom_compute_class/project.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/core/gke_enterprise/configmanagement/git/project.tf
+++ b/platforms/gke/base/core/gke_enterprise/configmanagement/git/project.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "anthosconfigmanagement_googleapis_com" {

--- a/platforms/gke/base/core/gke_enterprise/configmanagement/oci/project.tf
+++ b/platforms/gke/base/core/gke_enterprise/configmanagement/oci/project.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "anthosconfigmanagement_googleapis_com" {

--- a/platforms/gke/base/core/gke_enterprise/fleet_membership/container_cluster.tf
+++ b/platforms/gke/base/core/gke_enterprise/fleet_membership/container_cluster.tf
@@ -15,5 +15,5 @@
 data "google_container_cluster" "cluster" {
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/core/gke_enterprise/fleet_membership/membership.tf
+++ b/platforms/gke/base/core/gke_enterprise/fleet_membership/membership.tf
@@ -19,7 +19,7 @@ resource "google_gke_hub_membership" "cluster" {
   ]
 
   membership_id = data.google_container_cluster.cluster.name
-  project       = data.google_project.default.project_id
+  project       = data.google_project.cluster.project_id
 
   endpoint {
     gke_cluster {

--- a/platforms/gke/base/core/gke_enterprise/fleet_membership/project.tf
+++ b/platforms/gke/base/core/gke_enterprise/fleet_membership/project.tf
@@ -12,34 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "anthos_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "anthos.googleapis.com"
 }
 
 resource "google_project_service" "connectgateway_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "connectgateway.googleapis.com"
 }
 
 resource "google_project_service" "gkeconnect_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "gkeconnect.googleapis.com"
 }
 
 resource "google_project_service" "gkehub_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "gkehub.googleapis.com"
 }

--- a/platforms/gke/base/core/gke_enterprise/policycontroller/project.tf
+++ b/platforms/gke/base/core/gke_enterprise/policycontroller/project.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "anthospolicycontroller_googleapis_com" {

--- a/platforms/gke/base/core/gke_enterprise/servicemesh/container_cluster.tf
+++ b/platforms/gke/base/core/gke_enterprise/servicemesh/container_cluster.tf
@@ -15,5 +15,5 @@
 data "google_container_cluster" "cluster" {
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/core/gke_enterprise/servicemesh/project.tf
+++ b/platforms/gke/base/core/gke_enterprise/servicemesh/project.tf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "mesh_googleapis_com" {
@@ -26,6 +26,6 @@ resource "google_project_service" "mesh_googleapis_com" {
 resource "google_project_service" "meshconfig_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = true
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "meshconfig.googleapis.com"
 }

--- a/platforms/gke/base/core/initialize/local_file.tf
+++ b/platforms/gke/base/core/initialize/local_file.tf
@@ -123,8 +123,9 @@ resource "local_file" "shared_config_platform_auto_tfvars" {
 
   content = provider::terraform::encode_tfvars(
     {
-      platform_name        = var.platform_name
-      resource_name_prefix = var.resource_name_prefix
+      platform_default_project_id = var.platform_default_project_id
+      platform_name               = var.platform_name
+      resource_name_prefix        = var.resource_name_prefix
     }
   )
   file_permission = "0644"

--- a/platforms/gke/base/core/initialize/main.tf
+++ b/platforms/gke/base/core/initialize/main.tf
@@ -32,17 +32,13 @@ locals {
   )))
 }
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
-}
-
 resource "google_storage_bucket" "terraform" {
   for_each = toset(var.create_terraform_bucket ? ["create"] : [])
 
   force_destroy               = false
   location                    = var.cluster_region
   name                        = local.terraform_bucket_name
-  project                     = data.google_project.default.project_id
+  project                     = data.google_project.terraform.project_id
   uniform_bucket_level_access = true
 
   versioning {
@@ -54,7 +50,7 @@ data "google_storage_bucket" "terraform" {
   depends_on = [google_storage_bucket.terraform]
 
   name    = local.terraform_bucket_name
-  project = data.google_project.default.project_id
+  project = data.google_project.terraform.project_id
 }
 
 resource "local_file" "container_node_pools_files_for_region" {

--- a/platforms/gke/base/core/initialize/project.tf
+++ b/platforms/gke/base/core/initialize/project.tf
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
+}
+
+data "google_project" "terraform" {
+  project_id = local.terraform_project_id
 }
 
 resource "google_project_service" "cluster_compute_googleapis_com" {

--- a/platforms/gke/base/core/networking/project.tf
+++ b/platforms/gke/base/core/networking/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "compute_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "compute.googleapis.com"
 }

--- a/platforms/gke/base/core/workloads/custom_metrics_adapter/project.tf
+++ b/platforms/gke/base/core/workloads/custom_metrics_adapter/project.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/core/workloads/kueue/main.tf
+++ b/platforms/gke/base/core/workloads/kueue/main.tf
@@ -114,7 +114,7 @@ module "kubectl_wait" {
 
 resource "google_monitoring_dashboard" "kueue_monitoring_dashboard" {
   dashboard_json = file("${path.module}/dashboards/kueue-monitoring-dashboard.json")
-  project        = data.google_project.default.project_id
+  project        = data.google_project.cluster.project_id
 
   lifecycle {
     ignore_changes = [

--- a/platforms/gke/base/core/workloads/kueue/project.tf
+++ b/platforms/gke/base/core/workloads/kueue/project.tf
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/core/workloads/priority_class/project.tf
+++ b/platforms/gke/base/core/workloads/priority_class/project.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/README.md
+++ b/platforms/gke/base/use-cases/federated-learning/README.md
@@ -174,41 +174,44 @@ To deploy the reference architecture, you do the following:
 
    ```shell
    git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
-   cd accelerated-platforms
+   cd accelerated-platforms  && \
+   export ACP_REPO_DIR="$(pwd)"
    ```
 
-1. Configure the ID of the Google Cloud project where you want to initialize the
-   provisioning and configuration environment. This project will also contain
-   the remote Terraform backend. Add the following content to
-   `platforms/gke/base/_shared_config/terraform.auto.tfvars`:
+   To set the `ACP_REPO_DIR` value for new shell instances, write the value to
+   your shell initialization file.
+
+   `bash`
+
+   ```
+   sed -n -i -e '/^export ACP_REPO_DIR=/!p' -i -e '$aexport ACP_REPO_DIR="'"${ACP_REPO_DIR}"'"' ${HOME}/.bashrc
+   ```
+
+   `zsh`
+
+   ```
+   sed -n -i -e '/^export ACP_REPO_DIR=/!p' -i -e '$aexport ACP_REPO_DIR="'"${ACP_REPO_DIR}"'"' ${HOME}/.zshrc
+   ```
+
+1. Configure the ID of the default Google Cloud project to use for the
+   environment. This project will be used by default unless a project ID is
+   provided for a more specific setting
+   `${ACP_REPO_DIR}/platforms/gke/base/_shared_config/platform.auto.tfvars`:
 
    ```hcl
-   terraform_project_id = "<CONFIG_PROJECT_ID>"
+   terraform_project_id = "<PROJECT_ID>"
    ```
 
    Where:
 
-   - `<CONFIG_PROJECT_ID>` is the Google Cloud project ID.
-
-1. Configure the ID of the Google Cloud project where you want to deploy the
-   reference architecture by adding the following content to
-   `platforms/gke/base/_shared_config/cluster.auto.tfvars`:
-
-   ```hcl
-   cluster_project_id = "<PROJECT_ID>"
-   ```
-
-   Where:
-
-   - `<PROJECT_ID>` is the Google Cloud project ID. Can be different from
-     `<CONFIG_PROJECT_ID>`.
+   - `<PROJECT_ID>` is the Google Cloud project ID.
 
 1. Optionally configure a unique identifier to append to the name of all the
    resources in the reference architecture to identify a particular instance of
    the reference architecture, and to allow for multiple instances of the
    reference architecture to be deployed in the same Google Cloud project. To
    optionally configure the unique prefix, add the following content to
-   `platforms/gke/base/_shared_config/platform.auto.tfvars`:
+   `${ACP_REPO_DIR}/platforms/gke/base/_shared_config/platform.auto.tfvars`:
 
    ```hcl
    resource_name_prefix = "<RESOURCE_NAME_PREFIX>"
@@ -228,17 +231,18 @@ To deploy the reference architecture, you do the following:
 1. Run the script to provision the reference architecture:
 
    ```sh
-   "platforms/gke/base/use-cases/federated-learning/deploy.sh"
+   "${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/deploy.sh"
    ```
 
 It takes about 20 minutes to provision the reference architecture.
 
 ### Understand the deployment and destroy processes
 
-The `platforms/gke/base/use-cases/federated-learning/deploy.sh` script is a
-convenience script to orchestrate the provisioning and configuration of an
-instance of the reference architecture.
-`platforms/gke/base/use-cases/federated-learning/deploy.sh` does the following:
+The `${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/deploy.sh`
+script is a convenience script to orchestrate the provisioning and configuration
+of an instance of the reference architecture.
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/deploy.sh` does
+the following:
 
 1. Configure environment variables to reference libraries and other
    dependencies.
@@ -251,12 +255,14 @@ instance of the reference architecture.
 1. Provision and configures Google Cloud resources that the FL reference
    architecture depends on, augmenting the core platform.
 
-The `platforms/gke/base/use-cases/federated-learning/teardown.sh` script is a
-convenience script to orchestrate the destruction of an instance of the
-reference architecture.
-`platforms/gke/base/use-cases/federated-learning/teardown.sh` performs actions
-that are opposite to
-`platforms/gke/base/use-cases/federated-learning/deploy.sh`, in reverse order.
+The
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/teardown.sh`
+script is a convenience script to orchestrate the destruction of an instance of
+the reference architecture.
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/teardown.sh`
+performs actions that are opposite to
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/deploy.sh`, in
+reverse order.
 
 ## Next steps
 
@@ -287,15 +293,17 @@ To destroy an instance of the reference architecture, you do the following:
 You can configure the reference architecture by modifying files in the following
 directories:
 
-- `platforms/gke/base/_shared_config`
-- `platforms/gke/base/use-cases/federated-learning/terraform/_shared_config`
+- `${ACP_REPO_DIR}/platforms/gke/base/_shared_config`
+- `${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config`
 
 To add files to the package that Config Sync uses to sync cluster configuration:
 
 1. Copy the additional files in the
-   `platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/additional`
+   `${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/terraform/config_management/files/additional`
    directory.
-1. Run the `platforms/gke/base/use-cases/federated-learning/deploy.sh` script.
+1. Run the
+   `${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/deploy.sh`
+   script.
 
 ### Configure isolated runtime environments
 
@@ -313,7 +321,7 @@ For more information about the design of these tenants, see
 By default, this reference architecture configures one tenant. To configure
 additional tenants, or change their names, set the value of the
 `federated_learning_tenant_names` Terraform variable in
-`platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning.auto.tfvars`
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning.auto.tfvars`
 according to how many tenants you need. For example, to create two isolated
 tenants named `fl-1` and `fl-2`, you set the `federated_learning_tenant_names`
 variable as follows:
@@ -327,7 +335,7 @@ federated_learning_tenant_names = [
 
 For more information about the `federated_learning_tenant_names`, see its
 definition in
-`platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf`
+`${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf`
 
 ### Enable Confidential GKE Nodes
 
@@ -335,7 +343,7 @@ The reference architecture can optionally configure Confidential GKE Nodes using
 Terraform. To enable Confidential GKE Nodes, you do the following:
 
 1. Initialize the following Terraform variables in
-   `platforms/gke/base/_shared_config/cluster.auto.tfvars`:
+   `${ACP_REPO_DIR}/platforms/gke/base/_shared_config/cluster.auto.tfvars`:
 
    1. Set `cluster_confidential_nodes_enabled` to `true`
 
@@ -345,7 +353,7 @@ Terraform. To enable Confidential GKE Nodes, you do the following:
       [Encrypt workload data in-use with Confidential GKE Nodes](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes#availability).
 
 1. Initialize the following Terraform variables in
-   `platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning.auto.tfvars`:
+   `${ACP_REPO_DIR}/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning.auto.tfvars`:
 
    1. Set `federated_learning_node_pool_machine_type` to a machine type that
       supports Confidential GKE Nodes.

--- a/platforms/gke/base/use-cases/federated-learning/README.md
+++ b/platforms/gke/base/use-cases/federated-learning/README.md
@@ -166,9 +166,11 @@ controls to each Kubernetes namespace:
 
 To deploy the reference architecture, you do the following:
 
-1. [Install Terraform >= 1.8.0](https://developer.hashicorp.com/terraform/install).
-
 1. Open [Cloud Shell](https://cloud.google.com/shell).
+
+   To deploy this reference architecture, you need Terraform >= 1.8.0. For more
+   information about installing Terraform, see
+   [Install Terraform](https://developer.hashicorp.com/terraform/install).
 
 1. Clone this repository and change the working directory:
 

--- a/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/_shared_config/uc_federated_learning_variables.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  gke_robot_service_account           = "service-${data.google_project.default.number}@container-engine-robot.iam.gserviceaccount.com"
+  gke_robot_service_account           = "service-${data.google_project.cluster.number}@container-engine-robot.iam.gserviceaccount.com"
   gke_robot_service_account_iam_email = "serviceAccount:${local.gke_robot_service_account}"
 
   # Define values that other values depend on
@@ -23,7 +23,7 @@ locals {
       tenant_nodepool_name                               = format("%s-%s-p", local.cluster_name, name)
       tenant_nodepool_sa_name                            = format("%s-%s-n", local.cluster_name, name)
       tenant_apps_kubernetes_service_account_name        = local.tenant_apps_kubernetes_service_account_name
-      tenant_apps_workload_identity_service_account_name = "serviceAccount:${var.cluster_project_id}.svc.id.goog[${name}/${local.tenant_apps_kubernetes_service_account_name}]"
+      tenant_apps_workload_identity_service_account_name = "serviceAccount:${local.cluster_project_id}.svc.id.goog[${name}/${local.tenant_apps_kubernetes_service_account_name}]"
     }
   }
 
@@ -61,7 +61,7 @@ locals {
     external_services_allowed_namespaces = var.federated_learning_external_services_allowed_namespaces
   }
 
-  service_account_domain = "${var.cluster_project_id}.iam.gserviceaccount.com"
+  service_account_domain = "${local.cluster_project_id}.iam.gserviceaccount.com"
 
   node_pool_service_account_names = [
     for tenant in local.tenants : tenant.tenant_nodepool_sa_name

--- a/platforms/gke/base/use-cases/federated-learning/terraform/cloud_storage/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/cloud_storage/main.tf
@@ -18,7 +18,7 @@ resource "google_storage_bucket" "federated_learning_cloud_storage_buckets" {
   force_destroy               = each.value.force_destroy
   location                    = var.cluster_region
   name                        = join("-", [local.unique_identifier_prefix, each.key])
-  project                     = data.google_project.default.project_id
+  project                     = data.google_project.cluster.project_id
   uniform_bucket_level_access = true
 
   versioning {

--- a/platforms/gke/base/use-cases/federated-learning/terraform/cloud_storage/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/cloud_storage/project.tf
@@ -13,9 +13,5 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
-}
-
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/container_cluster.tf
@@ -15,5 +15,5 @@
 data "google_container_cluster" "cluster" {
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/config_management/project.tf
@@ -13,9 +13,5 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
-}
-
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_image_repository/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_image_repository/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "artifactregistry_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "artifactregistry.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/container_cluster.tf
@@ -15,5 +15,5 @@
 data "google_container_cluster" "cluster" {
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/main.tf
@@ -19,7 +19,7 @@ resource "google_container_node_pool" "fl_container_node_pool" {
   initial_node_count = 1
   location           = var.cluster_region
   name               = each.value.tenant_nodepool_name
-  project            = data.google_project.default.project_id
+  project            = data.google_project.cluster.project_id
 
   autoscaling {
     location_policy      = "BALANCED"

--- a/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/container_node_pool/project.tf
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/example_nvidia_flare_tff/firewall.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/example_nvidia_flare_tff/firewall.tf
@@ -26,7 +26,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = local.federated_learning_firewall_policy_name
   priority        = 1010
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-node-pools-allow-egress-nvidia-flare"
 
   target_service_accounts = flatten(concat(
@@ -49,7 +49,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = local.federated_learning_firewall_policy_name
   priority        = 1011
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-ingress-ingress-gateway-nvflare"
 
   target_service_accounts = flatten(concat(
@@ -82,7 +82,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = local.federated_learning_firewall_policy_name
   priority        = 1012
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-ingress-cloud-lb-health-checks-nvflare"
 
   target_service_accounts = flatten(concat(

--- a/platforms/gke/base/use-cases/federated-learning/terraform/example_nvidia_flare_tff/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/example_nvidia_flare_tff/project.tf
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/container_cluster.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/container_cluster.tf
@@ -15,5 +15,5 @@
 data "google_container_cluster" "cluster" {
   location = var.cluster_region
   name     = local.cluster_name
-  project  = data.google_project.default.project_id
+  project  = data.google_project.cluster.project_id
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/main.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/main.tf
@@ -21,14 +21,14 @@ data "google_service_account" "cluster" {
 resource "google_compute_network_firewall_policy" "federated_learning_fw_policy" {
   description = "Federated learning firewall policy"
   name        = local.federated_learning_firewall_policy_name
-  project     = data.google_project.default.project_id
+  project     = data.google_project.cluster.project_id
 }
 
 resource "google_compute_network_firewall_policy_association" "federated_learning_vpc_associations" {
   name              = "${local.cluster_name}-federated-learning-firewall-policy-association"
   attachment_target = data.google_compute_network.main_vpc_network.id
   firewall_policy   = google_compute_network_firewall_policy.federated_learning_fw_policy.name
-  project           = data.google_project.default.project_id
+  project           = data.google_project.cluster.project_id
 }
 
 resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_rule_deny_all" {
@@ -38,7 +38,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging          = true
   firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority                = 65535
-  project                 = data.google_project.default.project_id
+  project                 = data.google_project.cluster.project_id
   rule_name               = "${local.cluster_name}-node-pools-deny-egress"
   target_service_accounts = local.node_pool_service_account_emails
 
@@ -58,7 +58,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging          = true
   firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority                = 1000
-  project                 = data.google_project.default.project_id
+  project                 = data.google_project.cluster.project_id
   rule_name               = "${local.cluster_name}-node-pools-allow-egress-nodes-pods-services"
   target_service_accounts = local.node_pool_service_account_emails
 
@@ -81,7 +81,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging          = true
   firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority                = 1001
-  project                 = data.google_project.default.project_id
+  project                 = data.google_project.cluster.project_id
   rule_name               = "${local.cluster_name}-node-pools-allow-egress-api-server"
   target_service_accounts = local.node_pool_service_account_emails
 
@@ -102,7 +102,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging          = true
   firewall_policy         = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority                = 1002
-  project                 = data.google_project.default.project_id
+  project                 = data.google_project.cluster.project_id
   rule_name               = "${local.cluster_name}-node-pools-allow-egress-api-server"
   target_service_accounts = local.node_pool_service_account_emails
 
@@ -122,7 +122,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority        = 1003
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-intra-cluster-egress"
 
   target_service_accounts = concat(
@@ -154,7 +154,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority        = 1004
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-control-plane-ingress-webhooks"
 
   target_service_accounts = local.node_pool_service_account_emails
@@ -176,7 +176,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority        = 1006
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-ingress-ingress-gateway"
 
   target_service_accounts = local.node_pool_service_account_emails
@@ -206,7 +206,7 @@ resource "google_compute_network_firewall_policy_rule" "federated_learning_fw_ru
   enable_logging  = true
   firewall_policy = google_compute_network_firewall_policy.federated_learning_fw_policy.name
   priority        = 1007
-  project         = data.google_project.default.project_id
+  project         = data.google_project.cluster.project_id
   rule_name       = "${local.cluster_name}-ingress-cloud-lb-health-checks"
 
   target_service_accounts = flatten(concat(

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/networking.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/networking.tf
@@ -19,7 +19,7 @@ data "google_compute_network" "main_vpc_network" {
 
 data "google_compute_subnetwork" "region" {
   name    = local.subnetwork_name
-  project = data.google_project.default.project_id
+  project = data.google_project.cluster.project_id
   region  = var.cluster_region
 }
 

--- a/platforms/gke/base/use-cases/federated-learning/terraform/firewall/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/firewall/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "compute_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "compute.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/initialize/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/initialize/project.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "google_project" "cluster" {
-  project_id = var.cluster_project_id
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "cluster_cloudkms_googleapis_com" {

--- a/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/key_management_service/project.tf
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "cloudkms_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "cloudkms.googleapis.com"
 }
 
@@ -27,6 +27,6 @@ resource "google_project_service" "cloudkms_googleapis_com" {
 resource "google_project_service" "container_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "container.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/private_google_access/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/private_google_access/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "dns_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "dns.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/output.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/output.tf
@@ -19,5 +19,5 @@ output "federated_learning_kubernetes_service_account_name" {
 
 output "workload_identity_principal_prefix" {
   description = "Workload identity principal prefix"
-  value       = "principal://iam.googleapis.com/projects/${data.google_project.default.number}/locations/global/workloadIdentityPools/${data.google_project.default.project_id}.svc.id.goog/subject"
+  value       = "principal://iam.googleapis.com/projects/${data.google_project.cluster.number}/locations/global/workloadIdentityPools/${data.google_project.cluster.project_id}.svc.id.goog/subject"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/service_account/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/service_account/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "iam_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "iam.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
@@ -2,7 +2,7 @@
 
 ## Pull the source code
 
-- Clone the repository and change directory to the guide directory
+- Clone the repository and set the repository directory environment variable.
 
   ```
   git clone https://github.com/GoogleCloudPlatform/accelerated-platforms && \
@@ -35,36 +35,23 @@ precedence over earlier ones:
 - Any `-var` and `-var-file` options on the command line, in the order they are
   provided.
 
-- Set the cluster project ID
+For more information about providing values for Terraform input variables, see
+[Terraform input variables](https://developer.hashicorp.com/terraform/language/values/variables).
 
-  ```
-  export TF_VAR_cluster_project_id="<PROJECT_ID>"
-  ```
+- Set the platform default project ID
 
-  **-- OR --**
-
-  ```
-  vi ${ACP_REPO_DIR}/platforms/gke/base/_shared_config/cluster.auto.tfvars
-  ```
-
-  ```
-  cluster_project_id = "<PROJECT_ID>"
-  ```
-
-- Set the Terraform project ID
-
-  ```
-  export TF_VAR_terraform_project_id="<PROJECT_ID>"
+  ```shell
+  export TF_VAR_platform_default_project_id="<PROJECT_ID>"
   ```
 
   **-- OR --**
 
-  ```
-  vi ${ACP_REPO_DIR}/platforms/gke/base/_shared_config/terraform.auto.tfvars
+  ```shell
+  vi ${ACP_REPO_DIR}/platforms/gke/base/_shared_config/platform.auto.tfvars
   ```
 
-  ```
-  terraform_project_id = "<PROJECT_ID>"
+  ```hcl
+  platform_default_project_id = "<PROJECT_ID>"
   ```
 
 ## Deploy
@@ -73,12 +60,12 @@ To deploy this reference implementation, you need Terraform >= 1.8.0. For more
 information about installing Terraform, see
 [Install Terraform](https://developer.hashicorp.com/terraform/install).
 
-```
+```shell
 ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/deploy.sh
 ```
 
 ## Teardown
 
-```
+```shell
 ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/teardown.sh
 ```

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
@@ -2,6 +2,12 @@
 
 ## Pull the source code
 
+- Open [Cloud Shell](https://cloud.google.com/shell).
+
+  To deploy this reference implementation, you need Terraform >= 1.8.0. For more
+  information about installing Terraform, see
+  [Install Terraform](https://developer.hashicorp.com/terraform/install).
+
 - Clone the repository and set the repository directory environment variable.
 
   ```

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/iam.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/iam.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  workload_identity_principal_prefix = "principal://iam.googleapis.com/projects/${data.google_project.default.number}/locations/global/workloadIdentityPools/${data.google_project.default.project_id}.svc.id.goog/subject"
+  workload_identity_principal_prefix = "principal://iam.googleapis.com/projects/${data.google_project.cluster.number}/locations/global/workloadIdentityPools/${data.google_project.cluster.project_id}.svc.id.goog/subject"
 }
 
 resource "google_storage_bucket_iam_member" "ira_cloud_storage_bucket_iam_member" {

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/main.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/main.tf
@@ -17,8 +17,8 @@ resource "google_storage_bucket" "ira_cloud_storage_buckets" {
 
   force_destroy               = each.value.force_destroy
   location                    = var.cluster_region
-  name                        = join("-", [data.google_project.default.project_id, local.unique_identifier_prefix, each.key])
-  project                     = data.google_project.default.project_id
+  name                        = join("-", [data.google_project.cluster.project_id, local.unique_identifier_prefix, each.key])
+  project                     = data.google_project.cluster.project_id
   uniform_bucket_level_access = true
 
   hierarchical_namespace {

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/project.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/cloud_storage/project.tf
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
-  project_id = var.cluster_project_id
+data "google_project" "cluster" {
+  project_id = local.cluster_project_id
 }

--- a/test/ci-cd/cloudbuild/platforms-gke-base-core-terraform.yaml
+++ b/test/ci-cd/cloudbuild/platforms-gke-base-core-terraform.yaml
@@ -28,9 +28,8 @@ steps:
         export ACP_PLATFORM_BASE_DIR="/workspace/platforms/gke/base"
         export ACP_PLATFORM_CORE_DIR="/workspace/platforms/gke/base/core"
 
-        export TF_VAR_cluster_project_id="${PROJECT_ID}"
+        export TF_VAR_platform_default_project_id="${PROJECT_ID}"
         export TF_VAR_platform_name="commit-${SHORT_SHA}"
-        export TF_VAR_terraform_project_id="${PROJECT_ID}"
 
         platforms/gke/base/core/deploy.sh
         platforms/gke/base/core/deploy.sh

--- a/test/ci-cd/cloudbuild/platforms/gke/base/core/initialize.yaml
+++ b/test/ci-cd/cloudbuild/platforms/gke/base/core/initialize.yaml
@@ -14,9 +14,8 @@ steps:
 
 - args:
   - DEBUG=${_DEBUG}
-  - TF_VAR_cluster_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
+  - TF_VAR_platform_default_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
   - TF_VAR_platform_name="${SHORT_SHA}"
-  - TF_VAR_terraform_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
   entrypoint: "test/ci-cd/scripts/terraservice/configure_environment.sh"
   env:
   - BUILD_ID=${BUILD_ID}

--- a/test/ci-cd/cloudbuild/platforms/gke/base/core/workloads.yaml
+++ b/test/ci-cd/cloudbuild/platforms/gke/base/core/workloads.yaml
@@ -14,9 +14,8 @@ steps:
 
 - args:
   - DEBUG=${_DEBUG}
-  - TF_VAR_cluster_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
+  - TF_VAR_platform_default_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
   - TF_VAR_platform_name="${SHORT_SHA}"
-  - TF_VAR_terraform_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
   entrypoint: "test/ci-cd/scripts/terraservice/configure_environment.sh"
   env:
   - BUILD_ID=${BUILD_ID}

--- a/test/ci-cd/cloudbuild/platforms/gke/base/use-cases/inference-ref-arch/scripts.yaml
+++ b/test/ci-cd/cloudbuild/platforms/gke/base/use-cases/inference-ref-arch/scripts.yaml
@@ -60,12 +60,11 @@ steps:
         PROJECT_SUFFIX="${BUILD_ID}"
         PROJECT_SUFFIX="$${PROJECT_SUFFIX:0:7}"
 
-        export TF_VAR_cluster_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
+        export TF_VAR_platform_default_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
         export TF_VAR_platform_name="${SHORT_SHA}"
-        export TF_VAR_terraform_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
 
         # Create a dedicated project
-        export NEW_PROJECT_ID="$${TF_VAR_cluster_project_id}"
+        export NEW_PROJECT_ID="$${TF_VAR_platform_default_project_id}"
         test/ci-cd/scripts/create_project.sh
 
         $${ACP_PLATFORM_USE_CASE_DIR}/terraform/deploy.sh

--- a/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
+++ b/test/ci-cd/cloudbuild/uc-federated-learning-terraform.yaml
@@ -44,12 +44,11 @@ steps:
         PROJECT_SUFFIX="${BUILD_ID}"
         PROJECT_SUFFIX="$${PROJECT_SUFFIX:0:7}"
 
-        export TF_VAR_cluster_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
+        export TF_VAR_platform_default_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
         export TF_VAR_platform_name="${SHORT_SHA}-fl"
-        export TF_VAR_terraform_project_id="${PROJECT_ID}-$${PROJECT_SUFFIX}"
 
         # Create a dedicated project
-        export NEW_PROJECT_ID="$${TF_VAR_cluster_project_id}"
+        export NEW_PROJECT_ID="$${TF_VAR_platform_default_project_id}"
         test/ci-cd/scripts/create_project.sh
 
         # Deploy the base platform and the use case


### PR DESCRIPTION
Added a `platform_default_project_id` to simplify the deployment. This project ID will be used unless a project ID is provided by a more specific variable (e.g. `cluster_project_id`, `terraform_project_id`. 