### PR TITLE
fix: change project name to cluster to be consistent with other terraservices

### DIFF
--- a/platforms/gke/base/use-cases/federated-learning/terraform/network/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/network/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
+data "google_project" "cluster" {
   project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "networkservices_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "networkservices.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/pubsub/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/pubsub/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
+data "google_project" "cluster" {
   project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "pubsub_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "pubsub.googleapis.com"
 }

--- a/platforms/gke/base/use-cases/federated-learning/terraform/secret_manager/project.tf
+++ b/platforms/gke/base/use-cases/federated-learning/terraform/secret_manager/project.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "default" {
+data "google_project" "cluster" {
   project_id = local.cluster_project_id
 }
 
 resource "google_project_service" "secret_manager_googleapis_com" {
   disable_dependent_services = false
   disable_on_destroy         = false
-  project                    = data.google_project.default.project_id
+  project                    = data.google_project.cluster.project_id
   service                    = "secretmanager.googleapis.com"
 }


### PR DESCRIPTION
This PR renames default project to cluster to be consistent with other terraservices