### PR TITLE
chore: update devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,13 +64,14 @@
         }
       },
       "extensions": [
+        "docker.docker",
         "EditorConfig.EditorConfig",
         "esbenp.prettier-vscode",
         "googlecloudtools.cloudcode",
         "HashiCorp.terraform",
         "mads-hartmann.bash-ide-vscode",
         "mkhl.shfmt",
-        "ms-azuretools.vscode-docker",
+        "ms-azuretools.vscode-containers",
         "ms-python.black-formatter",
         "streetsidesoftware.code-spell-checker",
         "timonwong.shellcheck"


### PR DESCRIPTION
Install the new Docker extensions for VS Code in the devcontainer instead of the legacy one.