### PR TITLE
fix: permission issue to be able to see metrics from cloud monitoring

### DIFF
--- a/platforms/gke/base/core/workloads/custom_metrics_adapter/iam.tf
+++ b/platforms/gke/base/core/workloads/custom_metrics_adapter/iam.tf
@@ -18,7 +18,8 @@ locals {
 
 resource "google_project_iam_member" "custom_metrics_stackdriver_adapter" {
   for_each = toset([
-    "roles/monitoring.metricWriter"
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer"
   ])
 
   member  = "${local.wi_principal_prefix}/ns/custom-metrics/sa/custom-metrics-stackdriver-adapter"


### PR DESCRIPTION
This PR fixes an issue with custom metrics adapter not having permission to see metrics from Cloud Monitoring