### PR TITLE
Enabled container_node_pool terraservice

### DIFF
--- a/platforms/gke/base/core/deploy-standard.sh
+++ b/platforms/gke/base/core/deploy-standard.sh
@@ -27,8 +27,7 @@ MY_PATH="$(
 declare -a CORE_TERRASERVICES_APPLY_ARRAY=(
   "networking"
   "container_cluster"
-  # Disabled due to gke version role out
-  #"container_node_pool"
+  "container_node_pool"
   "gke_enterprise/fleet_membership"
   "workloads/cluster_credentials"
   "custom_compute_class"

--- a/test/ci-cd/scripts/platforms/gke/base/core/standard-full-deploy.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/core/standard-full-deploy.sh
@@ -32,8 +32,7 @@ ACP_PLATFORM_CORE_DIR="${ACP_PLATFORM_BASE_DIR}/core"
 declare -a CORE_TERRASERVICES_APPLY_ARRAY=(
   "networking"
   "container_cluster"
-  # Disabled due to gke version role out
-  #"container_node_pool"
+  "container_node_pool"
   "cloudbuild/initialize"
   "gke_enterprise/fleet_membership"
   "gke_enterprise/configmanagement/oci"

--- a/test/ci-cd/terraform/cloudbuild/cloudbuild_trigger.tf
+++ b/test/ci-cd/terraform/cloudbuild/cloudbuild_trigger.tf
@@ -282,8 +282,8 @@ locals {
   platforms_gke_base_core_full_scripts_include = [
     "platforms/gke/base/_shared_config/**",
     "platforms/gke/base/core/**",
-    "test/ci-cd/scripts/platforms/gke/base/core/core-full-deploy.sh",
-    "test/ci-cd/scripts/platforms/gke/base/core/core-full-teardown.sh",
+    "test/ci-cd/scripts/platforms/gke/base/core/standard-full-deploy.sh",
+    "test/ci-cd/scripts/platforms/gke/base/core/standard-full-teardown.sh",
     local.platforms_gke_base_core_full_scripts_cb_yaml,
   ]
 }
@@ -414,7 +414,9 @@ locals {
     "platforms/gke/base/core/workloads/auto_monitoring/**",
     "platforms/gke/base/core/workloads/cluster_credentials/**",
     "platforms/gke/base/core/workloads/kueue/**",
+    "platforms/gke/base/core/deploy.sh",
     "platforms/gke/base/core/deploy-ap.sh",
+    "platforms/gke/base/core/teardown.sh",
     "platforms/gke/base/core/teardown-ap.sh",
     local.platforms_gke_base_core_ap_scripts_cb_yaml,
   ]
@@ -485,7 +487,9 @@ locals {
     "platforms/gke/base/core/workloads/cluster_credentials/**",
     "platforms/gke/base/core/workloads/kueue/**",
     "platforms/gke/base/core/deploy.sh",
+    "platforms/gke/base/core/deploy-standard.sh",
     "platforms/gke/base/core/teardown.sh",
+    "platforms/gke/base/core/teardown-standard.sh",
     local.platforms_gke_base_core_scripts_cb_yaml,
   ]
 }


### PR DESCRIPTION
This PR is to verify when the GKE version roll out finishes and the container_node_pool can be re-enabled. 