### PR TITLE
fix: support non-bash shells in env scripts

### DIFF
--- a/platforms/gke/base/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/_shared_config/scripts/set_environment_variables.sh
@@ -15,7 +15,14 @@
 # limitations under the License.
 
 BASH_SOURCE_MY_PATH="$(
-  cd "$(dirname "${BASH_SOURCE}")" >/dev/null 2>&1
+  SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+  if [[ -z "${SCRIPT_SOURCE:-}" ]]; then
+    # Fallback in case BASH_SOURCE is not defined, such as when sourcing this
+    # script from a non-Bash shell
+    SCRIPT_SOURCE="$0"
+  fi
+
+  cd "$(dirname "${SCRIPT_SOURCE}")" >/dev/null 2>&1 || return 1
   pwd -P
 )"
 

--- a/platforms/gke/base/core/nvidia/initialize/README.md
+++ b/platforms/gke/base/core/nvidia/initialize/README.md
@@ -1,4 +1,4 @@
-# NVIDIA initialize
+# NVIDIA NGC initialization
 
 - Set environment variables.
 

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
@@ -149,10 +149,10 @@ For more information about providing values for Terraform input variables, see
 
 - Configure the platform.
 
-  - [Optional]
+  - \[Optional\]
     [Hugging Face initialization](/platforms/gke/base/core/huggingface/initialize/README.md)
-  - [Optional]
-    [NVIDIA initialization](/platforms/gke/base/core/nvidia/initialize/README.md)
+  - \[Optional\]
+    [NVIDIA NGC initialization](/platforms/gke/base/core/nvidia/initialize/README.md)
 
 ### Resources created
 
@@ -180,6 +180,7 @@ For more information about providing values for Terraform input variables, see
           <a href="/platforms/gke/base/core/custom_compute_class/templates/manifests/cpu">CPU</a>
         </summary>
         <ul>
+          <li>cpu-e2-s-16</li>
           <li>cpu-n4-s-8</li>
         <ul>
       </details>
@@ -207,7 +208,7 @@ For more information about providing values for Terraform input variables, see
         <ul>
       </details>
     - <details>
-        <summary>        
+        <summary>
           <a href="/platforms/gke/base/core/custom_compute_class/templates/manifests/tpu">TPU</a>
         </summary>
         <ul>

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh
@@ -14,7 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 MY_PATH_IRA_ENV="$(
-  cd "$(dirname "${BASH_SOURCE}")" >/dev/null 2>&1
+  SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+  if [[ -z "${SCRIPT_SOURCE:-}" ]]; then
+    # Fallback in case BASH_SOURCE is not defined, such as when sourcing this
+    # script from a non-Bash shell
+    SCRIPT_SOURCE="$0"
+  fi
+
+  cd "$(dirname "${SCRIPT_SOURCE}")" >/dev/null 2>&1 || return 1
   pwd -P
 )"
 
@@ -36,6 +43,7 @@ if [[ -v HF_MODEL_ID ]]; then
 
   HF_MODEL_NAME="${HF_MODEL_ID##*/}"
   HF_MODEL_NAME="${HF_MODEL_NAME//./-}"
-  HF_MODEL_NAME="${HF_MODEL_NAME,,}"
+  # Don't use ,, to make this portable across shells
+  HF_MODEL_NAME="$(echo "${HF_MODEL_NAME}" | tr '[:upper:]' '[:lower:]')"
   export HF_MODEL_NAME
 fi


### PR DESCRIPTION
- Update set_environment_variables.sh scripts to use SCRIPT_SOURCE with fallback to $0 for compatibility with Zsh and other shells.
- Replace Bash-specific lowercase conversion with portable 'tr'.
- Rename NVIDIA initialization to NVIDIA NGC initialization in docs.
- Document missing cpu-e2-s-16 in platform resources.