### PR TITLE
feat: deploy nvidia rtx pro 6000 cccs

### DIFF
--- a/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-2.yaml
+++ b/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-2.yaml
@@ -1,0 +1,96 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: gpu-rtx-pro-6000-96gb-x1-2
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  nodePoolConfig:
+    imageStreaming:
+      enabled: true
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+    # Use a specific reservation
+    # - gpu:
+    #     count: 1
+    #     driverVersion: latest
+    #     type: nvidia-rtx-pro-6000
+    #   machineType: g4-standard-24
+    #   maxPodsPerNode: 32
+    #   reservations:
+    #     affinity: Specific
+    #     specific:
+    #       - name: nvidia-rtx-pro-6000-specific
+    #         reservationBlock:
+    #           name: <RESERVATION_NAME>
+    #   spot: false
+
+    # Use any reservation
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-24
+      maxPodsPerNode: 32
+      reservations:
+        affinity: AnyBestEffort
+      spot: false
+
+    # Use on-demand
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-24
+      maxPodsPerNode: 32
+      spot: false
+
+    # Use DWS FlexStart with 7 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-24
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 604800
+
+    # Use DWS FlexStart with 1 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-24
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 86400
+
+    # Use spot
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-24
+      maxPodsPerNode: 32
+      spot: true

--- a/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-4.yaml
+++ b/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-4.yaml
@@ -1,0 +1,96 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: gpu-rtx-pro-6000-96gb-x1-4
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  nodePoolConfig:
+    imageStreaming:
+      enabled: true
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+    # Use a specific reservation
+    # - gpu:
+    #     count: 1
+    #     driverVersion: latest
+    #     type: nvidia-rtx-pro-6000
+    #   machineType: g4-standard-12
+    #   maxPodsPerNode: 32
+    #   reservations:
+    #     affinity: Specific
+    #     specific:
+    #       - name: nvidia-rtx-pro-6000-specific
+    #         reservationBlock:
+    #           name: <RESERVATION_NAME>
+    #   spot: false
+
+    # Use any reservation
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-12
+      maxPodsPerNode: 32
+      reservations:
+        affinity: AnyBestEffort
+      spot: false
+
+    # Use on-demand
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-12
+      maxPodsPerNode: 32
+      spot: false
+
+    # Use DWS FlexStart with 7 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-12
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 604800
+
+    # Use DWS FlexStart with 1 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-12
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 86400
+
+    # Use spot
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-12
+      maxPodsPerNode: 32
+      spot: true

--- a/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-8.yaml
+++ b/platforms/gke/base/core/custom_compute_class/templates/manifests/gpu/rtx-pro-6000-96gb/custom-compute-gpu-rtx-pro-6000-96gb-x1-8.yaml
@@ -1,0 +1,96 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: gpu-rtx-pro-6000-96gb-x1-8
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  nodePoolConfig:
+    imageStreaming:
+      enabled: true
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+    # Use a specific reservation
+    # - gpu:
+    #     count: 1
+    #     driverVersion: latest
+    #     type: nvidia-rtx-pro-6000
+    #   machineType: g4-standard-6
+    #   maxPodsPerNode: 32
+    #   reservations:
+    #     affinity: Specific
+    #     specific:
+    #       - name: nvidia-rtx-pro-6000-specific
+    #         reservationBlock:
+    #           name: <RESERVATION_NAME>
+    #   spot: false
+
+    # Use any reservation
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-6
+      maxPodsPerNode: 32
+      reservations:
+        affinity: AnyBestEffort
+      spot: false
+
+    # Use on-demand
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-6
+      maxPodsPerNode: 32
+      spot: false
+
+    # Use DWS FlexStart with 7 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-6
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 604800
+
+    # Use DWS FlexStart with 1 day limit
+    - flexStart:
+        enabled: true
+        nodeRecycling:
+          leadTimeSeconds: 3600
+      gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-6
+      maxPodsPerNode: 32
+      maxRunDurationSeconds: 86400
+
+    # Use spot
+    - gpu:
+        count: 1
+        driverVersion: latest
+        type: nvidia-rtx-pro-6000
+      machineType: g4-standard-6
+      maxPodsPerNode: 32
+      spot: true

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
@@ -206,6 +206,10 @@ For more information about providing values for Terraform input variables, see
           <li>gpu-l4-24gb-x2</li>
           <li>gpu-l4-24gb-x4</li>
           <li>gpu-l4-24gb-x8</li>
+          <li>gpu-rtx-pro-6000-96gb-x1</li>
+          <li>gpu-rtx-pro-6000-96gb-x1-2</li>
+          <li>gpu-rtx-pro-6000-96gb-x1-4</li>
+          <li>gpu-rtx-pro-6000-96gb-x1-8</li>
         <ul>
       </details>
     - <details>


### PR DESCRIPTION
Configure three new custom ComputeClasses for available fractional NVIDIA RTX 6000 Pro shapes (1/2, 1/4, 1/8).