### PR TITLE
feat: n4-8 custom computeclass

### DIFF
--- a/platforms/gke/base/core/custom_compute_class/templates/manifests/cpu/n4/custom-compute-cpu-n4-8.yaml
+++ b/platforms/gke/base/core/custom_compute_class/templates/manifests/cpu/n4/custom-compute-cpu-n4-8.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: cpu-n4-8
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  nodePoolConfig:
+    imageStreaming:
+      enabled: true
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+    # Use reservations if available
+    - machineType: n4-standard-8
+      maxPodsPerNode: 64
+      reservations:
+        affinity: AnyBestEffort
+      spot: false
+
+    # Use on-demand
+    - machineType: n4-standard-8
+      maxPodsPerNode: 64
+      spot: false

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md
@@ -181,6 +181,7 @@ For more information about providing values for Terraform input variables, see
         </summary>
         <ul>
           <li>cpu-e2-s-16</li>
+          <li>cpu-n4-8</li>
           <li>cpu-n4-s-8</li>
         <ul>
       </details>


### PR DESCRIPTION
Add a n4-8 custom ComputeClass running n4-standard-8 nodes. Differently from the existing n4-s-8 custom ComputeClass, n4-8 doesn't fall back to spot capacity, making it useful for workloads that don't tolerate disruptions caused by Spot VM node pre-emption.