### PR TITLE
feat: k6 benchmark image build service

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/inference-ref-arch_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/inference-ref-arch_variables.tf
@@ -59,6 +59,8 @@ locals {
 
   ira_online_gpu_diffusers_sglang_diffusers_image_url = var.ira_online_gpu_sglang_diffusers_image_url != null ? var.ira_online_gpu_sglang_diffusers_image_url : "${local.cloudbuild_ar_image_repository_url}/gpu/sglang:latest"
 
+  ira_cpu_k6_benchmark_image_url = var.ira_cpu_k6_benchmark_image_url != null ? var.ira_cpu_k6_benchmark_image_url : "${local.cloudbuild_ar_image_repository_url}/cpu/k6-benchmark:latest"
+
   ira_online_tpu_kubernetes_namespace_name       = var.ira_online_tpu_kubernetes_namespace_name != null ? var.ira_online_tpu_kubernetes_namespace_name : "${local.unique_identifier_prefix}-online-tpu"
   ira_online_tpu_kubernetes_service_account_name = var.ira_online_tpu_kubernetes_service_account_name != null ? var.ira_online_tpu_kubernetes_service_account_name : "${local.unique_identifier_prefix}-online-tpu"
   ira_online_tpu_max_diffusion_sdxl_image_url    = var.ira_online_tpu_max_diffusion_sdxl_image_url != null ? var.ira_online_tpu_max_diffusion_sdxl_image_url : "${local.cloudbuild_ar_image_repository_url}/tpu-max-diffusion/sdxl:latest"
@@ -221,6 +223,11 @@ variable "ira_online_gpu_diffusers_flux_image_url" {
   type        = string
 }
 
+variable "ira_cpu_k6_benchmark_image_url" {
+  default     = null
+  description = "The URL for the k6 benchmark container image."
+  type        = string
+}
 
 variable "ira_online_gpu_kubernetes_namespace_name" {
   default     = null

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/outputs.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/outputs.tf
@@ -160,6 +160,10 @@ output "ira_offline_batch_project_id" {
   value = local.ira_offline_batch_project_id
 }
 
+output "ira_cpu_k6_benchmark_image_url" {
+  value = local.ira_cpu_k6_benchmark_image_url
+}
+
 output "ira_online_gpu_diffusers_flux_image_url" {
   value = local.ira_online_gpu_diffusers_flux_image_url
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/.terraform.lock.hcl
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.49.2"
+  constraints = "6.49.2"
+  hashes = [
+    "h1:+B64rc5fCMrWtjZIsQGx/fftYiQnSInfqrLs76PZNH0=",
+    "zh:04dbba38cc201d8f35f21c65fe5fe022b2ef30712c59d0b04df1182ee484ee29",
+    "zh:37478f37b696e214049a7c1e397a6ebcf6b10e3652a6275c5e99ef972a0cd17f",
+    "zh:3a68292e88e6612ed014e22d53a693859071337fcc49a244936094ae8f2b82d8",
+    "zh:4adc8c706652b6c170c520bd3815abba7e145aeec26a2abdfa8a98ae85fbfc0d",
+    "zh:5e8dbf922be32eb54c370260fd71e8124d4d7a3bddc2d0e6b47b15efc30a2224",
+    "zh:632bccc9396e61947242095738164ae27db060b1c172422b41e3b12e80236ecc",
+    "zh:66ee64a5621199868c8fa68492124d38b37e1d733d240508c595b124b5123cb7",
+    "zh:6843060f0673a4e556c248672171c8a29c7faeaee9954cdffeb19a55de7e5184",
+    "zh:87d3b0bd397de17ea6c8b34c898afb9f08eda28c6c6272d8dd75fe17ceef77f3",
+    "zh:9d2f0f93f4506dc0002c2dec1b2117626b6376c214653b71629a933ce77e3523",
+    "zh:e80ccae3d640dca17b496220e3f42f6f0cc4c6fb80ffae9e2bbaea446373c137",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.5.3"
+  constraints = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_cloudbuild.auto.tfvars
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_cloudbuild.auto.tfvars
@@ -1,0 +1,1 @@
+../../../_shared_config/_cloudbuild.auto.tfvars

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_cloudbuild_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_cloudbuild_variables.tf
@@ -1,0 +1,1 @@
+../../../_shared_config/_cloudbuild_variables.tf

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_inference-ref-arch.auto.tfvars
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_inference-ref-arch.auto.tfvars
@@ -1,0 +1,1 @@
+../../../_shared_config/inference-ref-arch.auto.tfvars

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_inference-ref-arch_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_inference-ref-arch_variables.tf
@@ -1,0 +1,1 @@
+../../../_shared_config/inference-ref-arch_variables.tf

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_platform.auto.tfvars
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_platform.auto.tfvars
@@ -1,0 +1,1 @@
+../../../_shared_config/_platform.auto.tfvars

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_platform_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/_platform_variables.tf
@@ -1,0 +1,1 @@
+../../../_shared_config/_platform_variables.tf

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/cloudbuild.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/cloudbuild.tf
@@ -1,0 +1,45 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  image_destination = local.ira_async_cpu_load_generator_image_url
+}
+
+resource "terraform_data" "submit_docker_build_k6_benchmark" {
+  input = {
+    acp_root                      = local.acp_root
+    cloudbuild_project_id         = local.cloudbuild_project_id
+    cloudbuild_service_account_id = local.cloudbuild_service_account_id
+    cloudbuild_source_bucket_name = local.cloudbuild_source_bucket_name
+    image_destination             = local.ira_cpu_k6_benchmark_image_url
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+gcloud builds submit \
+--config="cloudbuild.yaml" \
+--gcs-source-staging-dir="gs://${self.input.cloudbuild_source_bucket_name}/source" \
+--project="${self.input.cloudbuild_project_id}" \
+--quiet \
+--service-account="${self.input.cloudbuild_service_account_id}" \
+--substitutions=_DESTINATION="${self.input.image_destination}"
+EOT
+    interpreter = ["bash", "-c"]
+    working_dir = "${local.acp_root}/container-images/cpu/k6-benchmark"
+  }
+
+  triggers_replace = {
+    source_hash = sha256(join("", [for file in fileset("${local.acp_root}/container-images/cpu/k6-benchmark", "**") : filesha256("${local.acp_root}/container-images/cpu/k6-benchmark/${file}")]))
+  }
+}

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/local_file.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/local_file.tf
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  acp_root = "${path.module}/../../../../../../../../.."
+}

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/versions.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/versions.tf
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.49.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.3"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "cloud-solutions/acp_ira_images_cpu_batch_load_generator_deploy-v1"
+  }
+}


### PR DESCRIPTION
Prepare a service to build the k6 container image. By running terraform apply on this service, you submit a Cloud Build job to build container-images/cpu/k6-benchmark and publish it on the configured Artifact Registry repository.