### PR TITLE
feat: k6 deployment descriptors

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/job.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/job.yaml
@@ -1,0 +1,71 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k6-benchmark
+  namespace: replaced-by-kustomize
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: k6-benchmark
+      annotations:
+        gke-gcsfuse/volumes: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - args: []
+          command: []
+          image: replaced-by-kustomize
+          imagePullPolicy: Always
+          name: k6-benchmark
+          resources: {}
+          volumeMounts:
+            - mountPath: /output
+              name: k6-benchmark-bucket-results
+              readOnly: false
+          env:
+            - name: TARGET_URL
+              valueFrom:
+                configMapKeyRef:
+                  key: K6_TARGET_URL
+                  name: deployment
+            - name: ACCELERATOR_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: ACCELERATOR_NAME
+                  name: deployment
+            - name: SCENARIOS_JSON
+              valueFrom:
+                configMapKeyRef:
+                  key: K6_SCENARIOS_JSON
+                  name: deployment
+            - name: INFERENCE_SERVER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  key: INFERENCE_SERVER_TYPE
+                  name: deployment
+      serviceAccountName: replaced-by-kustomize
+      terminationGracePeriodSeconds: 0
+      volumes:
+        - csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              bucketName: replaced-by-kustomize
+              mountOptions: "implicit-dirs,uid=12345,gid=12345"
+          name: k6-benchmark-bucket-results

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/kustomization.yaml
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - deployment.env
+    name: deployment
+    namespace: replaced-by-kustomize
+
+resources:
+  - job.yaml

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/templates/deployment.tpl.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/base/templates/deployment.tpl.env
@@ -1,0 +1,8 @@
+INFERENCE_KUBERNETES_NAMESPACE=${ira_online_gpu_kubernetes_namespace_name}
+INFERENCE_KUBERNETES_SERVICE_ACCOUNT=${ira_inference_perf_bench_kubernetes_service_account_name}
+CONTAINER_IMAGE_URL=${ira_cpu_k6_benchmark_image_url}
+ACCELERATOR_NAME=${ACCELERATOR_TYPE}
+BENCHMARK_RESULTS_BUCKET_NAME=${hub_models_bucket_bench_results_name}
+K6_TARGET_URL=${K6_TARGET_URL}
+K6_SCENARIOS_JSON=${K6_SCENARIOS_JSON}
+INFERENCE_SERVER_TYPE=${K6_INFERENCE_SERVER_TYPE}

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/configure_deployment.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/configure_deployment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+MY_PATH="$(
+  cd "$(dirname "$0")" >/dev/null 2>&1
+  pwd -P
+)"
+
+source "${MY_PATH}/../../terraform/_shared_config/scripts/set_environment_variables.sh"
+
+if [[ -z "${ACCELERATOR_TYPE:-}" ]]; then
+  echo "ACCELERATOR_TYPE is not set"
+  return 1
+fi
+
+if [[ -z "${HF_MODEL_NAME:-}" ]]; then
+  echo "HF_MODEL_NAME is not set"
+  echo "If the HF_MODEL_NAME variable is not set, ensure that HF_MODEL_ID is set and source the set_environment_variables.sh script:"
+  echo "source \"${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh\""
+  return 1
+fi
+
+if [[ -z "${K6_SCENARIOS_JSON:-}" ]]; then
+  echo "K6_SCENARIOS_JSON is not set."
+  return 1
+fi
+export K6_SCENARIOS_JSON
+
+echo "Configuring deployment for ${HF_MODEL_NAME} running on ${ACCELERATOR_TYPE}"
+
+if [[ "${HF_MODEL_NAME:-}" == "flux-2-klein-4b" ]]; then
+  K6_TARGET_URL="http://diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME}:8000"
+  K6_INFERENCE_SERVER_TYPE="sglang"
+elif [[ "${HF_MODEL_NAME:-}" == "flux-1-schnell" ]]; then
+  K6_TARGET_URL="http://diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME}:8000/generate"
+  K6_INFERENCE_SERVER_TYPE="diffusers"
+else
+  echo "Model not supported: ${HF_MODEL_NAME:-"HF_MODEL_NAME variable not set"}"
+  return 1
+fi
+
+export K6_TARGET_URL
+export K6_INFERENCE_SERVER_TYPE
+
+envsubst <"${MY_PATH}/base/templates/deployment.tpl.env" | sponge "${MY_PATH}/base/deployment.env"
+
+echo "Deployment configuration:"
+cat "${MY_PATH}/base/deployment.env"

--- a/test/ci-cd/scripts/platforms/gke/base/use-cases/inference-ref-arch/validate_kustomize.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/use-cases/inference-ref-arch/validate_kustomize.sh
@@ -69,6 +69,12 @@ export APP_LABEL="vllm-rtx-pro-6000-gemma-3-27b-it-sd-eagle"
 "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm-spec-decoding/sd-eagle/configure_benchmark.sh"
 "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/vllm-spec-decoding/configure_vllm_spec_decoding.sh"
 
+# Validate k6-benchmark kustomize
+export ACCELERATOR_TYPE="l4"
+export HF_MODEL_NAME="HF_MODEL_NAME"
+export K6_REQUEST_BATCH_SIZE=1
+"${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/configure_deployment.sh"
+
 # Validate offline-batch-inference-gpu kustomize
 export ACCELERATOR_TYPE="rtx-pro-6000"
 export HF_MODEL_ID="meta-llama/Llama-3.3-70B-Instruct"


### PR DESCRIPTION
Provide a Kustomize overlay to deploy k6 on the platform.

k6 is configured to run as a Job, and supports dynamic configuration of:

- The benchmark scenario to run
- The target endpoint