### PR TITLE
chore: consolidate and upgrade core ML dependencies

### DIFF
--- a/container-images/gpu/diffusers-flux/src/requirements.txt
+++ b/container-images/gpu/diffusers-flux/src/requirements.txt
@@ -1,9 +1,10 @@
 accelerate==1.10.1
-diffusers==0.35.1
+diffusers==0.38.1
 fastapi[standard]==0.116.0
-pillow==12.1.1
-protobuf==6.32.0
+pillow==12.2.1
+protobuf==7.35.0
 sentencepiece==0.2.1
-transformers==4.53.0
+transformers==5.9.0
 torch>=2.5.0
 uvicorn==0.35.0
+

--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/diffusers-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/diffusers-with-hf-model.md
@@ -132,7 +132,7 @@ This example is built on top of the
     > set and source the `set_environment_variables.sh` script:
     >
     > ```shell
-    > source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"`
+    > source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
     > ```
 
   - Select an accelerator.


### PR DESCRIPTION
## Description
This PR consolidates and resolves a backlog of 4 separate dependency updates originally opened by Dependabot. Combining these into a single PR allows us to test interlocking machine learning framework updates collectively, avoid merge conflicts on the shared `requirements.txt` file, and save CI/CD build queue time.

Additionally, this PR includes a minor documentation fix to correct a typo in `docs/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/diffusers-with-hf-model.md`.

### Combined Dependabot PRs Addressed:
1. **#415**: [Bump `transformers` from 4.53.0 to 5.0.0rc3](https://github.com/GoogleCloudPlatform/accelerated-platforms/pull/415) (Upgraded to stable release path `5.9.0`)
2. **#418**: [Bump `pillow` from 12.1.1 to 12.2.0](https://github.com/GoogleCloudPlatform/accelerated-platforms/pull/418/) in `/container-images/gpu/diffusers-flux/src`
3. **#421**: [Bump `diffusers` from 0.35.1 to 0.38.0](https://github.com/GoogleCloudPlatform/accelerated-platforms/pull/421) in `/container-images/gpu/diffusers-flux/src`
4. **#365**: [Bump `protobuf` versioning](https://github.com/GoogleCloudPlatform/accelerated-platforms/pull/365) to resolve overlapping dependency constraints

## How Has This Been Tested?
- Successfully built the container image and deployed the `black-forest-labs/flux.1-schnell` model on a Google Cloud **L4 GPU** instance. 
- Confirmed that the `inference-server` container pipeline components load completely and `uvicorn` spins up cleanly on port 8000 and inference run successfully.