### PR TITLE
Configuring dependabot to ignore fine-tuning folder in gke/ai-ml/playground 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://github.com/google/addlicense
+#
 version: 2
 updates:
   # 1. Configuration for Python dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # 1. Configuration for Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "use-cases/model-fine-tuning-pipeline/fine-tuning/**"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://github.com/google/addlicense
-#
 version: 2
 updates:
   # 1. Configuration for Python dependencies
@@ -23,4 +21,5 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "use-cases/model-fine-tuning-pipeline/fine-tuning/**"
+      - "use-cases/model-fine-tuning-pipeline/data-preparation/**"
 


### PR DESCRIPTION
This PR configures Dependabot to ignore the following folders:
/use-cases/model-fine-tuning-pipeline/fine-tuning/ 
use-cases/model-fine-tuning-pipeline/data-preparation/

Since the fine-tuning use case has been migrated from gke/ai-ml/playground to gke/base/platform, we no longer need Dependabot tracking dependencies in thess playground paths.