### PR TITLE
feat: deploy flux.2 on sglang

### DIFF
--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/diffusers-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/online-inference-gpu/diffusers-with-hf-model.md
@@ -8,233 +8,290 @@ This example is built on top of the
 
 ## Before you begin
 
-- The
-  [GKE Inference reference implementation](/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md)
-  is deployed and configured.
+1. Deploy and configure the
+   [GKE Inference reference implementation](/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md).
 
-- Get access to the models.
+1. Get access to the models.
 
-  - For FLUX.1-schnell:
+   - For FLUX.1-schnell:
 
-    - Accept the conditions to access its files and content on the Hugging Face
-      model page.
-      - [**black-forest-labs/FLUX.1-schnell**](https://huggingface.co/black-forest-labs/FLUX.1-schnell)
+     - Accept the conditions to access its files and content on the Hugging Face
+       model page.
+       - [**black-forest-labs/FLUX.1-schnell**](https://huggingface.co/black-forest-labs/FLUX.1-schnell)
 
-- Ensure your
-  [Hugging Face Hub **Read** access token](/platforms/gke/base/core/huggingface/initialize/README.md)
-  has been added to Secret Manager.
+   - For FLUX.2-klein-4B: The model is not gated, so there's no license check.
+
+1. Ensure your
+   [Hugging Face Hub **Read** access token](/platforms/gke/base/core/huggingface/initialize/README.md)
+   has been added to Secret Manager.
 
 ## Create and configure the Google Cloud resources
 
-- Deploy the online GPU resources.
+1. Deploy the online GPU resources.
 
-  ```shell
-  export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
-  cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/online_gpu && \
-  rm -rf .terraform/ terraform.tfstate* && \
-  terraform init && \
-  terraform plan -input=false -out=tfplan && \
-  terraform apply -input=false tfplan && \
-  rm tfplan
-  ```
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/online_gpu && \
+   rm -rf .terraform/ terraform.tfstate* && \
+   terraform init && \
+   terraform plan -input=false -out=tfplan && \
+   terraform apply -input=false tfplan && \
+   rm tfplan
+   ```
 
 ## Download the model to Cloud Storage
 
-- Choose the model.
+1. Choose the model.
 
-  - **FLUX.1-Schnell**:
+   - [**FLUX.1-schnell**](https://huggingface.co/black-forest-labs/FLUX.1-schnell):
 
-    ```shell
-    export HF_MODEL_ID="black-forest-labs/flux.1-schnell"
-    ```
+     ```shell
+     export HF_MODEL_ID="black-forest-labs/flux.1-schnell"
+     ```
 
-- Source the environment configuration.
+   - [**FLUX.2-klein-4B**](https://huggingface.co/black-forest-labs/FLUX.2-klein-4B):
 
-  ```shell
-  source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
-  ```
+     ```shell
+     export HF_MODEL_ID="black-forest-labs/flux.2-klein-4b"
+     ```
 
-- Configure the model download job.
+1. Source the environment configuration.
 
-  ```shell
-  "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/configure_huggingface.sh"
-  ```
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
 
-- Deploy the model download job.
+1. Configure the model download job.
 
-  ```shell
-  kubectl apply --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/huggingface"
-  ```
+   ```shell
+   "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/configure_huggingface.sh"
+   ```
 
-- Watch the model download job until it is complete.
+1. Deploy the model download job.
 
-  ```shell
-  watch --color --interval 5 --no-title \
-  "kubectl --namespace=${huggingface_hub_downloader_kubernetes_namespace_name} get job/${HF_MODEL_ID_HASH}-hf-model-to-gcs | GREP_COLORS='mt=01;92' egrep --color=always -e '^' -e 'Complete'
-  echo '\nLogs(last 10 lines):'
-  kubectl --namespace=${huggingface_hub_downloader_kubernetes_namespace_name} logs job/${HF_MODEL_ID_HASH}-hf-model-to-gcs --all-containers --tail 10"
-  ```
+   ```shell
+   kubectl apply --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/huggingface"
+   ```
 
-  When the job is complete, you will see the following:
+1. Watch the model download job until it is complete.
 
-  ```text
-  NAME                       STATUS     COMPLETIONS   DURATION   AGE
-  XXXXXXXX-hf-model-to-gcs   Complete   1/1           ###        ###
-  ```
+   ```shell
+   watch --color --interval 5 --no-title \
+   "kubectl --namespace=${huggingface_hub_downloader_kubernetes_namespace_name} get job/${HF_MODEL_ID_HASH}-hf-model-to-gcs | GREP_COLORS='mt=01;92' egrep --color=always -e '^' -e 'Complete'
+   echo '\nLogs(last 10 lines):'
+   kubectl --namespace=${huggingface_hub_downloader_kubernetes_namespace_name} logs job/${HF_MODEL_ID_HASH}-hf-model-to-gcs --all-containers --tail 10"
+   ```
 
-  You can press `CTRL`+`c` to terminate the watch.
+   When the job is complete, you will see the following:
 
-- Delete the model download job.
+   ```text
+   NAME                       STATUS     COMPLETIONS   DURATION   AGE
+   XXXXXXXX-hf-model-to-gcs   Complete   1/1           ###        ###
+   ```
 
-  ```shell
-  kubectl delete --ignore-not-found --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/huggingface"
-  ```
+   You can press `CTRL`+`c` to terminate the watch.
+
+1. Delete the model download job.
+
+   ```shell
+   kubectl delete --ignore-not-found --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/model-download/huggingface"
+   ```
 
 ## Build the container image
 
-- Source the environment configuration.
+1. Source the environment configuration.
 
-  ```shell
-  source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
-  ```
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
 
-- Build the container image for the Diffusers inference server.
+1. Build the container image for the Diffusers inference server.
 
-  ```shell
-  export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
-  cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux && \
-  rm -rf .terraform/ terraform.tfstate* && \
-  terraform init && \
-  terraform plan -input=false -out=tfplan && \
-  terraform apply -input=false tfplan && \
-  rm tfplan
-  ```
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   rm -rf ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux/.terraform/ terraform.tfstate* && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux init && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux plan -input=false -out=tfplan && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux apply -input=false tfplan && \
+   rm ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux/tfplan
+   ```
 
-  > The build usually takes 10 to 15 minutes.
+   The build usually takes about 25 minutes.
 
 ## Deploy the inference workload
 
-- Source the environment configuration.
+1. Source the environment configuration.
 
-  ```shell
-  source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
-  ```
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
 
-- Set the environment variables for the workload.
+1. Check the model name.
 
-  - Check the model name.
+   ```shell
+   echo "HF_MODEL_NAME=${HF_MODEL_NAME}"
+   ```
 
-    ```shell
-    echo "HF_MODEL_NAME=${HF_MODEL_NAME}"
-    ```
+   > If the `HF_MODEL_NAME` variable is not set, ensure that `HF_MODEL_ID` is
+   > set and source the `set_environment_variables.sh` script:
+   >
+   > ```shell
+   > source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   > ```
 
-    > If the `HF_MODEL_NAME` variable is not set, ensure that `HF_MODEL_ID` is
-    > set and source the `set_environment_variables.sh` script:
-    >
-    > ```shell
-    > source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
-    > ```
+   > If the `HF_MODEL_NAME` variable is not set, ensure that `HF_MODEL_ID` is
+   > set and source the `set_environment_variables.sh` script:
+   >
+   > ```shell
+   > source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   > ```
 
-  - Select an accelerator.
+   | Model           | NVIDIA L4 | 2x NVIDIA L4 | 4x NVIDIA L4 | NVIDIA H100 | NVIDIA RTX Pro 6000 | 1/2 NVIDIA RTX Pro 6000 | 1/4 NVIDIA RTX Pro 6000 | 1/8 NVIDIA RTX Pro 6000 |
+   | --------------- | --------- | ------------ | ------------ | ----------- | ------------------- | ----------------------- | ----------------------- | ----------------------- |
+   | flux.1-schnell  | ✅        | Not tested   | Not tested   | ✅          | Not tested          | Not tested              | Not tested              | Not tested              |
+   | flux.2-klein-4B | ✅        | ✅           | ✅           | Not tested  | ✅                  | ✅                      | ✅                      | ❌                      |
 
-    | Model          | l4  | h100 |
-    | -------------- | --- | ---- |
-    | flux.1-schnell | ✅  | ✅   |
+   > When using fractional GPUs (1/2, 1/4, 1/8), you might see a warning in the
+   > logs of the `inference-server` container:
+   > `No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'`. You can
+   > ignore this warning. It's due to the GPU virtualization layer masking
+   > hardware probes from the PyTorch JIT compiler. It does not affect inference
+   > performance or stability.
 
-    - **NVIDIA Tesla L4 24GB**:
+   - **NVIDIA Tesla L4 24GB**:
 
-      ```shell
-      export ACCELERATOR_TYPE="l4"
-      ```
+     - 1x **NVIDIA Tesla L4**:
 
-    - **NVIDIA H100 80GB**:
+       ```shell
+       export ACCELERATOR_TYPE="l4"
+       ```
 
-      ```shell
-      export ACCELERATOR_TYPE="h100"
-      ```
+     - 2x **NVIDIA Tesla L4**:
 
-    Ensure that you have enough quota in your project to provision the selected
-    accelerator type. For more information, see about viewing GPU quotas, see
-    [Allocation quotas: GPU quota](https://cloud.google.com/compute/resource-usage#gpu_quota).
+       ```shell
+       export ACCELERATOR_TYPE="l4-x2"
+       ```
 
-- Configure the deployment.
+     - 4x **NVIDIA Tesla L4**:
 
-  ```shell
-  "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh"
-  ```
+       ```shell
+       export ACCELERATOR_TYPE="l4-x4"
+       ```
 
-- Deploy the inference workload.
+   - 1x **NVIDIA H100 80GB**:
 
-  ```shell
-  kubectl apply --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/${ACCELERATOR_TYPE}-${HF_MODEL_NAME}"
-  ```
+     ```shell
+     export ACCELERATOR_TYPE="h100"
+     ```
 
-- Watch the deployment until it is ready.
+   - **NVIDIA RTX Pro 6000**:
 
-  ```shell
-  watch --color --interval 5 --no-title \
-  "kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} get deployment/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} | GREP_COLORS='mt=01;92' egrep --color=always -e '^' -e '1/1     1            1'
-  echo '\nLogs(last 10 lines):'
-  kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} logs deployment/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} --all-containers --tail 10"
-  ```
+     - 1x **NVIDIA RTX Pro 6000**:
 
-  When the deployment is ready, you will see the following:
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000"
+       ```
 
-  ```text
-  NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
-  diffusers-<ACCELERATOR_TYPE>-<HF_MODEL_NAME>   1/1     1            1           ###
-  ```
+     - 1/2x (half) of a **NVIDIA RTX Pro 6000**:
 
-  You can press `CTRL`+`c` to terminate the watch.
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-2"
+       ```
 
-- Send a test request.
+     - 1/4x (one fourth) of a **NVIDIA RTX Pro 6000**:
 
-  ```shell
-  kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} port-forward service/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} 8000:8000 >/dev/null &
-  PF_PID=$!
-  while ! echo -e '\x1dclose\x0d' | telnet localhost 8000 >/dev/null 2>&1; do
-    sleep 0.1
-  done
-  curl http://localhost:8000/generate \
-  --data '{
-    "height": 512,
-    "num_inference_steps": 4,
-    "prompt": "A photo of a dog playing fetch in a park.",
-    "width": 512
-  }' \
-  --header "Content-Type: application/json" \
-  --output ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/images/${HF_MODEL_NAME}_${ACCELERATOR_TYPE}_image.png \
-  --request POST \
-  --show-error \
-  --silent
-  ls -alh ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/images/${HF_MODEL_NAME}_${ACCELERATOR_TYPE}_image.png
-  kill -9 ${PF_PID}
-  ```
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-4"
+       ```
 
-- Delete the workload.
+     - 1/8x (one eight) of a **NVIDIA RTX Pro 6000**:
 
-  ```shell
-  kubectl delete --ignore-not-found --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/${ACCELERATOR_TYPE}-${HF_MODEL_NAME}"
-  ```
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-8"
+       ```
+
+   Ensure that you have enough quota in your project to provision the selected
+   accelerator type. For more information, see about viewing GPU quotas, see
+   [Allocation quotas: GPU quota](https://cloud.google.com/compute/resource-usage#gpu_quota).
+
+1. Configure the deployment.
+
+   ```shell
+   "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh"
+   ```
+
+1. Deploy the inference workload.
+
+   ```shell
+   kubectl apply --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/${ACCELERATOR_TYPE}-${HF_MODEL_NAME}"
+   ```
+
+1. Watch the deployment until it is ready.
+
+   ```shell
+   watch --color --interval 5 --no-title \
+   "kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} get deployment/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} | GREP_COLORS='mt=01;92' egrep --color=always -e '^' -e '1/1     1            1'
+   echo '\nLogs(last 10 lines):'
+   kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} logs deployment/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} --all-containers --tail 10"
+   ```
+
+   When the deployment is ready, you will see the following:
+
+   ```text
+   NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
+   diffusers-<ACCELERATOR_TYPE>-<HF_MODEL_NAME>   1/1     1            1           ###
+   ```
+
+   You can press `CTRL`+`c` to terminate the watch.
+
+1. Send a test request.
+
+   ```shell
+   kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} port-forward service/diffusers-${ACCELERATOR_TYPE}-${HF_MODEL_NAME} 8000:8000 >/dev/null &
+   PF_PID=$!
+   while ! echo -e '\x1dclose\x0d' | telnet localhost 8000 >/dev/null 2>&1; do
+     sleep 0.1
+   done
+   curl http://localhost:8000/generate \
+   --data '{
+     "height": 512,
+     "num_inference_steps": 4,
+     "prompt": "A photo of a dog playing fetch in a park.",
+     "width": 512
+   }' \
+   --header "Content-Type: application/json" \
+   --output ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/images/${HF_MODEL_NAME}_${ACCELERATOR_TYPE}_image.png \
+   --request POST \
+   --show-error \
+   --silent
+   ls -alh ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/images/${HF_MODEL_NAME}_${ACCELERATOR_TYPE}_image.png
+   kill -9 ${PF_PID}
+   ```
+
+1. Delete the workload.
+
+   ```shell
+   kubectl delete --ignore-not-found --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/${ACCELERATOR_TYPE}-${HF_MODEL_NAME}"
+   ```
 
 ## Clean up
 
-- Destroy the container image.
+1. Destroy the container image.
 
-  ```shell
-  export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
-  cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux && \
-  rm -rf .terraform/ terraform.tfstate* && \
-  terraform init &&
-  terraform destroy -auto-approve
-  ```
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/gpu/diffusers_flux && \
+   rm -rf .terraform/ terraform.tfstate* && \
+   terraform init &&
+   terraform destroy -auto-approve
+   ```
 
-- Destroy the online GPU resources.
+1. Destroy the online GPU resources.
 
-  ```shell
-  export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
-  cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/online_gpu && \
-  rm -rf .terraform/ terraform.tfstate* && \
-  terraform init &&
-  terraform destroy -auto-approve
-  ```
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/online_gpu && \
+   rm -rf .terraform/ terraform.tfstate* && \
+   terraform init &&
+   terraform destroy -auto-approve
+   ```

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/kustomization.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+configMapGenerator:
+  - files:
+      - patch-entrypoint.sh
+    name: entrypoint-patch
+    namespace: replaced-by-kustomize
+
+patches:
+  - path: patch-server.yaml
+  - path: patch-gcsfuse.yaml

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-entrypoint.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# Dynamic python patch of parallel_state.py
+python3 -c "
+path = '/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py'
+with open(path, 'r') as f:
+    content = f.read()
+
+old_code = '''        extra_args = (
+            {}
+            if (
+                current_platform.is_mps()
+                or current_platform.is_musa()
+                or current_platform.is_npu()
+            )
+            else dict(device_id=device_id)
+        )'''
+
+new_code = '''        extra_args = (
+            {}
+            if (
+                current_platform.is_mps()
+                or current_platform.is_musa()
+                or current_platform.is_npu()
+                or world_size == 1
+            )
+            else dict(device_id=device_id)
+        )'''
+
+if old_code in content:
+    content = content.replace(old_code, new_code)
+    with open(path, 'w') as f:
+        f.write(content)
+    print('[Patch] Successfully patched parallel_state.py!')
+else:
+    print('[Patch] Target code not found or already patched.')
+"
+
+# Execute normal SGLang binary entrypoint with arguments
+exec sglang "$@"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-gcsfuse.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-gcsfuse.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This patch overrides the base GCS Fuse configuration for virtual GPU slices.
+# Deviation from base:
+# 1. file-cache:max-size-mb is set to 0 (disabled).
+# 2. parallel downloads are disabled (implied by removing the flag).
+# Rationale: Virtual GPU slices run on memory-constrained host node pools.
+# Disabling the RAM-based file cache prevents node-level evictions and sidecar
+# OOM crashes during model weight prefetching.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      volumes:
+        - name: huggingface-hub-model-bucket
+          csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              mountOptions: metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:negative-ttl-secs:0,file-cache:max-size-mb:0,implicit-dirs,file-system:kernel-list-cache-ttl-secs:-1,only-dir:replaced-by-kustomize

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-server.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base-vgpu/patch-server.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          # The normal sglang command is wrapped by patch-entrypoint.sh.
+          # This startup wrapper dynamically patches sglang's parallel_state.py
+          # to omit the 'device_id' argument in torch.distributed.init_process_group
+          # when world_size == 1.
+          #
+          # Why: PyTorch's eager device connection hook (eager_connect_single_device)
+          # is triggered when device_id is passed, which attempts direct GPU/NCCL hardware
+          # binding calls that crash with 'cudaErrorNotSupported' inside virtualized
+          # MIG / vGPU slice sandboxes under GKE. Delaying NCCL init (which is never
+          # called on tp=1 setups) bypasses the crash entirely.
+          #
+          # Tracked in SGLang Issue: https://github.com/sgl-project/sglang/issues/25670
+          command:
+            - "/scripts/patch-entrypoint.sh"
+          args:
+            - "serve"
+            - "--mem-fraction-static=$(GPU_MEMORY_UTILIZATION)"
+            - "--model-path=/gcs/$(MODEL_ID)"
+            - "--tp-size=$(TENSOR_PARALLEL_SIZE)"
+            - "--trust-remote-code"
+            - "--port=30000"
+            - "--host=0.0.0.0"
+          env:
+            - name: NCCL_P2P_DISABLE
+              value: "1"
+            - name: NCCL_SHM_DISABLE
+              value: "1"
+            - name: NCCL_NVLS_ENABLE
+              value: "0"
+            - name: NCCL_DEBUG
+              value: "INFO"
+          volumeMounts:
+            - mountPath: /scripts
+              name: entrypoint-patch-volume
+      volumes:
+        - name: entrypoint-patch-volume
+          configMap:
+            name: entrypoint-patch
+            defaultMode: 0755

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base/deployment.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/base/deployment.yaml
@@ -85,8 +85,8 @@ spec:
               path: /health
               port: 8000
               scheme: HTTP
-            initialDelaySeconds: 60
-            periodSeconds: 10
+            initialDelaySeconds: 120
+            periodSeconds: 30
             successThreshold: 1
             timeoutSeconds: 1
           resources: {}

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh
@@ -29,6 +29,9 @@ source "${MY_PATH}/../../../terraform/_shared_config/scripts/set_environment_var
 if [[ "${HF_MODEL_ID}" == "black-forest-labs/flux.1-schnell" ]]; then
   DIFFUSERS_CONTAINER_IMAGE_URL="${ira_online_gpu_diffusers_flux_image_url}"
   DIFFUSERS_INFERENCE_SERVER="diffusers"
+elif [[ "${HF_MODEL_ID}" == "black-forest-labs/flux.2-klein-4b" ]]; then
+  DIFFUSERS_CONTAINER_IMAGE_URL="${ira_online_gpu_diffusers_sglang_diffusers_image_url}"
+  DIFFUSERS_INFERENCE_SERVER="sglang"
 else
   echo "[ERROR] Set a container image URL for model: ${HF_MODEL_ID:-"no model set"}"
   return 1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,142 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -l4-flux-2-klein-4b
+
+patches:
+  - path: patch-server.yaml
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-l4-24gb-s16-x1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-server.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/patch-server.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          command:
+            - sglang
+            - serve
+          args:
+            - "--mem-fraction-static=$(GPU_MEMORY_UTILIZATION)"
+            - "--model-path=/gcs/$(MODEL_ID)"
+            - "--tp-size=$(TENSOR_PARALLEL_SIZE)"
+            - "--trust-remote-code"
+            - "--port=30000"
+            - "--host=0.0.0.0"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-flux-2-klein-4b/runtime.env
@@ -1,0 +1,5 @@
+APP_LABEL=diffusers-l4-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,142 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -l4-x2-flux-2-klein-4b
+
+patches:
+  - path: patch-server.yaml
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-l4-24gb-x2

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "20"
+              memory: 80G
+              nvidia.com/gpu: "2"
+            requests:
+              cpu: "20"
+              memory: 80G
+              nvidia.com/gpu: "2"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-server.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/patch-server.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          env:
+            - name: NUM_GPUS
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime
+                  key: NUM_GPUS
+            - name: TENSOR_PARALLEL_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime
+                  key: TENSOR_PARALLEL_SIZE
+          command:
+            - sglang
+            - serve
+          args:
+            - "--model-path=/gcs/$(MODEL_ID)"
+            - "--tp-size=$(TENSOR_PARALLEL_SIZE)"
+            - "--trust-remote-code"
+            - "--port=30000"
+            - "--host=0.0.0.0"
+            - "--backend=sglang"
+            - "--num-gpus=$(NUM_GPUS)"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x2-flux-2-klein-4b/runtime.env
@@ -1,0 +1,6 @@
+APP_LABEL=diffusers-l4-x2-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=2
+NUM_GPUS=2

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,142 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -l4-x4-flux-2-klein-4b
+
+patches:
+  - path: patch-server.yaml
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-l4-24gb-x4

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "40"
+              memory: 160G
+              nvidia.com/gpu: "4"
+            requests:
+              cpu: "40"
+              memory: 160G
+              nvidia.com/gpu: "4"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-server.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/patch-server.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          env:
+            - name: NUM_GPUS
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime
+                  key: NUM_GPUS
+            - name: TENSOR_PARALLEL_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime
+                  key: TENSOR_PARALLEL_SIZE
+          command:
+            - sglang
+            - serve
+          args:
+            - "--model-path=/gcs/$(MODEL_ID)"
+            - "--tp-size=$(TENSOR_PARALLEL_SIZE)"
+            - "--trust-remote-code"
+            - "--port=30000"
+            - "--host=0.0.0.0"
+            - "--backend=sglang"
+            - "--num-gpus=$(NUM_GPUS)"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/l4-x4-flux-2-klein-4b/runtime.env
@@ -1,0 +1,6 @@
+APP_LABEL=diffusers-l4-x4-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=4
+NUM_GPUS=4

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,141 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -rtx-pro-6000-1-2-flux-2-klein-4b
+
+patches:
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base-vgpu

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-rtx-pro-6000-96gb-x1-2

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    metadata:
+      annotations:
+        devices.gke.io/container.inference-server: |+
+          - path: /dev/nvidia-caps/nvidia-cap1
+          - path: /dev/nvidia-caps/nvidia-cap2
+          - path: /dev/nvidia-caps/nvidia-cap3
+          - path: /dev/nvidia-caps/nvidia-cap4
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-2-flux-2-klein-4b/runtime.env
@@ -1,0 +1,5 @@
+APP_LABEL=diffusers-rtx-pro-6000-1-2-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,141 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -rtx-pro-6000-1-4-flux-2-klein-4b
+
+patches:
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base-vgpu

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-rtx-pro-6000-96gb-x1-4

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    metadata:
+      annotations:
+        devices.gke.io/container.inference-server: |+
+          - path: /dev/nvidia-caps/nvidia-cap1
+          - path: /dev/nvidia-caps/nvidia-cap2
+          - path: /dev/nvidia-caps/nvidia-cap3
+          - path: /dev/nvidia-caps/nvidia-cap4
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "6"
+              memory: 38G
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "6"
+              memory: 38G
+              nvidia.com/gpu: "1"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-1-4-flux-2-klein-4b/runtime.env
@@ -1,0 +1,5 @@
+APP_LABEL=diffusers-rtx-pro-6000-1-4-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,142 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -rtx-pro-6000-flux-2-klein-4b
+
+patches:
+  - path: patch-server.yaml
+  - path: patch-ports.yaml
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.INFERENCE_SERVER
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/inference-server]
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.selector.matchLabels.app
+          - spec.template.metadata.labels.app
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.selector.app
+        select:
+          kind: Service
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: diffusers
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=inference-server].image
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Service
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.MODEL_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.bucketName
+        options:
+          delimiter: .
+          index: 0
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_ID
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=huggingface-hub-model-bucket].csi.volumeAttributes.mountOptions
+        options:
+          delimiter: "only-dir:"
+          index: 1
+        select:
+          kind: Deployment
+      - fieldPaths:
+          - spec.template.spec.containers.[name=fetch-safetensors].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+          - spec.template.spec.containers.[name=inference-server].volumeMounts.[name=huggingface-hub-model-bucket].mountPath
+        options:
+          delimiter: /
+          index: 2
+        select:
+          kind: Deployment
+  - source:
+      fieldPath: data.MODEL_NAME
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.[ai.gke.io/model]
+        select:
+          kind: Deployment
+
+resources:
+  - ../base

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: gpu-rtx-pro-6000-96gb-x1

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-ports.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-ports.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          readinessProbe:
+            httpGet:
+              port: 30000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  ports:
+    - port: 8000
+      protocol: TCP
+      targetPort: 30000

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          resources:
+            limits:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "6"
+              memory: 45G
+              nvidia.com/gpu: "1"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-server.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/patch-server.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: diffusers
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference-server
+          command:
+            - sglang
+            - serve
+          args:
+            - "--mem-fraction-static=$(GPU_MEMORY_UTILIZATION)"
+            - "--model-path=/gcs/$(MODEL_ID)"
+            - "--tp-size=$(TENSOR_PARALLEL_SIZE)"
+            - "--trust-remote-code"
+            - "--port=30000"
+            - "--host=0.0.0.0"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/rtx-pro-6000-flux-2-klein-4b/runtime.env
@@ -1,0 +1,5 @@
+APP_LABEL=diffusers-rtx-pro-6000-flux-2-klein-4b
+GPU_MEMORY_UTILIZATION=0.95
+MODEL_ID=black-forest-labs/flux.2-klein-4b
+MODEL_NAME=flux-2-klein-4b
+TENSOR_PARALLEL_SIZE=1

--- a/test/ci-cd/scripts/platforms/gke/base/use-cases/inference-ref-arch/validate_kustomize.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/use-cases/inference-ref-arch/validate_kustomize.sh
@@ -53,6 +53,8 @@ export ACCELERATOR_TYPE="l4"
 # Validate diffusers kustomize
 export HF_MODEL_ID="black-forest-labs/flux.1-schnell"
 "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh"
+export HF_MODEL_ID="black-forest-labs/flux.2-klein-4b"
+"${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-gpu/diffusers/configure_diffusers.sh"
 
 export ACCELERATOR_TYPE="v5e"
 "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/online-inference-tpu/max-diffusion/configure_max_diffusion.sh"


### PR DESCRIPTION
Deploy flux.2-klein-4b on SGLang running on:

- NVIDIA L4 (x1, x2, x4)
- NVIDIA RTX 6000 Pro (x1, 1/2, 1/4)

This change does the following:

- Update the deployment guide for diffusion models to include `flux.2-klein-4B` as an option.
- Add a base Kustomize layer for workloads to deploy on vGPUs. This base layer contains an SGLang patch that's necessary until https://github.com/sgl-project/sglang/issues/25670 is fixed.
- Add `black-forest-labs/flux.2-klein-4b` as a deployment option in the deployment configuration and validation scripts