### PR TITLE
feat: flux.2 benchmark

### DIFF
--- a/container-images/cpu/k6-benchmark/scripts/k6-diffusers-flux-2-klein-4b.js
+++ b/container-images/cpu/k6-benchmark/scripts/k6-diffusers-flux-2-klein-4b.js
@@ -1,0 +1,250 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import exec from "k6/execution";
+
+const TARGET_URL = __ENV.TARGET_URL || "http://localhost:8000/generate";
+const ACCELERATOR_NAME = __ENV.ACCELERATOR_NAME || "unknown";
+const INFERENCE_SERVER_TYPE = __ENV.INFERENCE_SERVER_TYPE || "unknown";
+
+// Extract hostname for deployment_name tag
+const urlMatch = TARGET_URL.match(/https?:\/\/([^\/:]+)/);
+const DEPLOYMENT_NAME = urlMatch ? urlMatch[1] : "unknown";
+
+// Parse dynamic scenarios
+if (!__ENV.SCENARIOS_JSON) {
+  throw new Error("SCENARIOS_JSON environment variable is required.");
+}
+
+let configScenarios = [];
+try {
+  configScenarios = JSON.parse(__ENV.SCENARIOS_JSON);
+} catch (e) {
+  throw new Error(`Failed to parse SCENARIOS_JSON: ${e.message}`);
+}
+
+const MODEL_ID = configScenarios[0].model_id || "unknown";
+const SEED = 42;
+
+// Validate first scenario for warmup
+if (
+  !configScenarios[0].width ||
+  !configScenarios[0].height ||
+  !configScenarios[0].steps
+) {
+  throw new Error(
+    "Each scenario in SCENARIOS_JSON must specify 'width', 'height', and 'steps'.",
+  );
+}
+
+console.log(
+  `Loaded ${configScenarios.length} benchmark scenarios for model ${MODEL_ID}: ${JSON.stringify(configScenarios)}`,
+);
+
+// Lookup table for scenario configurations
+const SCENARIO_CONFIGS = {
+  warmup: {
+    batch: configScenarios[0].batch,
+    vus: configScenarios[0].vus,
+    steps: configScenarios[0].steps,
+    width: configScenarios[0].width,
+    height: configScenarios[0].height,
+    model_id: MODEL_ID,
+  },
+};
+
+// Build k6 scenarios object
+const scenarios = {
+  warmup: {
+    executor: "constant-vus",
+    vus: configScenarios[0].vus,
+    duration: "5m",
+    exec: "generate",
+    tags: {
+      scenario: "warmup",
+      batch_size: configScenarios[0].batch.toString(),
+      vus: configScenarios[0].vus.toString(),
+      num_inference_steps: configScenarios[0].steps.toString(),
+      width: configScenarios[0].width.toString(),
+      height: configScenarios[0].height.toString(),
+      inference_server: INFERENCE_SERVER_TYPE,
+    },
+  },
+};
+
+let currentTimeOffsetSeconds = 300; // 5m warmup
+const COOL_DOWN_SECONDS = 30;
+
+configScenarios.forEach((s, index) => {
+  if (!s.width || !s.height || !s.steps) {
+    throw new Error(
+      `Scenario ${index} is missing required fields: width, height, or steps.`,
+    );
+  }
+  const accelTag = (__ENV.ACCELERATOR_NAME || "unknown")
+    .toLowerCase()
+    .replace(/_/g, "-");
+  const scenarioName = `bench_${accelTag}_b${s.batch}_v${s.vus}_s${s.steps}_r${s.width}x${s.height}`;
+  const startTime = currentTimeOffsetSeconds + index * COOL_DOWN_SECONDS;
+
+  scenarios[scenarioName] = {
+    executor: "constant-vus",
+    vus: s.vus,
+    duration: s.duration || "10m",
+    startTime: `${startTime}s`,
+    exec: "generate",
+    tags: {
+      scenario: scenarioName,
+      batch_size: s.batch.toString(),
+      vus: s.vus.toString(),
+      num_inference_steps: s.steps.toString(),
+      width: s.width.toString(),
+      height: s.height.toString(),
+      inference_server: INFERENCE_SERVER_TYPE,
+    },
+  };
+
+  SCENARIO_CONFIGS[scenarioName] = {
+    batch: s.batch,
+    vus: s.vus,
+    steps: s.steps,
+    width: s.width,
+    height: s.height,
+    model_id: s.model_id || MODEL_ID,
+  };
+
+  let durationSeconds = 600; // 10m default
+  if (typeof s.duration === "string") {
+    if (s.duration.endsWith("m"))
+      durationSeconds = parseInt(s.duration.slice(0, -1)) * 60;
+    else if (s.duration.endsWith("s"))
+      durationSeconds = parseInt(s.duration.slice(0, -1));
+  }
+  currentTimeOffsetSeconds += durationSeconds;
+});
+
+export const options = {
+  tags: {
+    model: MODEL_ID,
+    accelerator: ACCELERATOR_NAME,
+    seed: SEED.toString(),
+    target_url: TARGET_URL,
+    deployment_name: DEPLOYMENT_NAME,
+  },
+  discardResponseBodies: false, // Need body for validation and error reporting
+  scenarios: scenarios,
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+  },
+};
+
+const params = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+  timeout: "120s",
+};
+
+export function setup() {
+  console.log(`Starting dynamic k6 load test against: ${TARGET_URL}`);
+  console.log(
+    `Running ${Object.keys(scenarios).length} scenarios (including warmup)`,
+  );
+}
+
+let lastScenario = "";
+let consecutiveFailures = 0;
+let abortCurrentScenario = false;
+
+export function generate() {
+  const scenarioName = exec.scenario.name;
+  const config = SCENARIO_CONFIGS[scenarioName];
+
+  if (!config) {
+    throw new Error(`No configuration found for scenario: ${scenarioName}`);
+  }
+
+  if (scenarioName !== lastScenario) {
+    console.log(
+      `VU ${exec.vu.idInTest} starting scenario: ${scenarioName} (Batch: ${config.batch}, VUs: ${config.vus})`,
+    );
+    lastScenario = scenarioName;
+    consecutiveFailures = 0;
+    abortCurrentScenario = false;
+  }
+
+  if (abortCurrentScenario) {
+    sleep(1);
+    return;
+  }
+
+  let payload;
+  let endpoint = TARGET_URL;
+
+  if (INFERENCE_SERVER_TYPE === "sglang") {
+    endpoint = `${TARGET_URL}/v1/images/generations`;
+    payload = JSON.stringify({
+      model: `/gcs/${config.model_id}`,
+      prompt:
+        "A highly detailed, cinematic photograph of a futuristic city skyline at sunset, neon lights, 8k resolution, photorealistic",
+      n: config.batch,
+      size: `${config.width}x${config.height}`,
+      num_inference_steps: config.steps,
+      seed: SEED,
+      response_format: "b64_json",
+    });
+  } else {
+    payload = JSON.stringify({
+      prompt:
+        "A highly detailed, cinematic photograph of a futuristic city skyline at sunset, neon lights, 8k resolution, photorealistic",
+      width: config.width,
+      height: config.height,
+      num_inference_steps: config.steps,
+      seed: SEED,
+      batch_size: config.batch,
+    });
+  }
+
+  if (consecutiveFailures === 0) {
+      console.log(`Endpoint: ${endpoint}`);
+      console.log(`Payload: ${payload}`);
+  }
+
+  const res = http.post(endpoint, payload, params);
+
+  const success = check(res, {
+    "is status 200": (r) => r.status === 200,
+    "has body": (r) => r.body && r.body.length > 0,
+  });
+
+  if (!success) {
+    consecutiveFailures++;
+    if (consecutiveFailures === 1) {
+      console.error(
+        `Request failed! Status: ${res.status}. Body: ${res.body || "empty"}`,
+      );
+    }
+    if (consecutiveFailures >= 3) {
+      console.error(`Scenario ${scenarioName} aborted due to 3 consecutive failures.`);
+      abortCurrentScenario = true;
+    }
+    sleep(1);
+  } else {
+    consecutiveFailures = 0;
+  }
+
+  sleep(0.01);
+}

--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/inf-perf-benchmarking-with-k6-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/inf-perf-benchmarking-with-k6-hf-model.md
@@ -1,0 +1,425 @@
+# GKE Inference Benchmarking with k6
+
+This example sets up a benchmarking job on Google Kubernetes Engine (GKE),
+leveraging the Inference reference-architecture for model deployment and the k6
+open-source tool for scalable benchmarking.
+
+This implementation deploys the k6 as a Kubernetes Job and can be customized
+with different load scenarios and datasets.
+
+This example is built on top of the
+[GKE Inference reference architecture](/docs/platforms/gke/base/use-cases/inference-ref-arch/README.md).
+
+## Before you begin
+
+1. Deploy and configure the
+   [GKE Inference reference implementation](/platforms/gke/base/use-cases/inference-ref-arch/terraform/README.md).
+
+### Requirements
+
+This guide was designed to be run from
+[Cloud Shell](https://cloud.google.com/shell) in the Google Cloud console. Cloud
+Shell has the following tools installed:
+
+- [Google Cloud Command Line Interface (`gcloud` CLI)](https://cloud.google.com/cli)
+- `curl`
+- `envsubst`
+- `jq`
+- `kubectl`
+- `sponge`
+
+## Create and configure the Google Cloud resources
+
+1. Source the environment configuration.
+
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
+
+1. Update terraform environment variables depending on the accelerators being
+   used (GPU/TPU/BOTH). Example:
+
+   ```shell
+   export TF_VAR_enable_gpu=true
+   export TF_VAR_enable_tpu=false
+   ```
+
+1. Deploy the benchmark infrastructure:
+
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   rm -rf "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench/.terraform/terraform.tfstate" && \
+   terraform -chdir="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench" init && \
+   terraform -chdir="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench" plan -input=false -out=tfplan && \
+   terraform -chdir="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench" apply -input=false tfplan && \
+   rm "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench/tfplan"
+   ```
+
+## Define the Benchmarking Configuration
+
+1. Choose a model:
+
+   - [**FLUX.2-klein-4B**](https://huggingface.co/black-forest-labs/FLUX.2-klein-4B):
+
+     ```shell
+     export HF_MODEL_ID="black-forest-labs/flux.2-klein-4b"
+     ```
+
+1. Select an accelerator:
+
+   | Model           | l4  | RTX Pro 6000 |
+   | --------------- | --- | ------------ |
+   | flux.2-klein-4b | ✅  | ✅           |
+
+   - 1x **NVIDIA Tesla L4 24GB**, running on a `g2-standard-16` Google
+     Kubernetes Engine node:
+
+     ```shell
+     export ACCELERATOR_TYPE="l4"
+     ```
+
+   - **NVIDIA RTX Pro 6000**:
+
+     - 1x **NVIDIA RTX Pro 6000**:
+
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000"
+       ```
+
+     - 1/2 (half) of a **NVIDIA RTX Pro 6000**:
+
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-2"
+       ```
+
+     - 1/4 (one fourth) of a **NVIDIA RTX Pro 6000**:
+
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-4"
+       ```
+
+     - 1/8 (one eight) of a **NVIDIA RTX Pro 6000**:
+
+       ```shell
+       export ACCELERATOR_TYPE="rtx-pro-6000-1-8"
+       ```
+
+   Ensure that you have enough quota in your project to provision the selected
+   accelerator type. For more information, see about viewing GPU quotas, see
+   [Allocation quotas: GPU quota](https://cloud.google.com/compute/resource-usage#gpu_quota).
+
+1. Configure sequential benchmarking scenarios using the `K6_SCENARIOS_JSON`
+   variable. This variable accepts a JSON array of objects, where each object
+   represents a specific load configuration to be tested sequentially.
+
+   ```shell
+   export K6_SCENARIOS_JSON='[{"batch": 1, "vus": 1, "width": 512, "height": 512, "steps": 10}, {"batch": 2, "vus": 4, "width": 512, "height": 512, "steps": 10}]'
+   ```
+
+   **JSON Attribute Definitions:**
+
+   - **`batch`**: The number of prompts sent in a single inference request.
+     Larger batch sizes generally increase GPU utilization but also increase
+     request latency.
+   - **`vus`**: Virtual Users. The number of concurrent worker threads sending
+     requests to the server. Increasing VUs helps saturate the GPU by filling
+     compute gaps between individual requests.
+   - **`duration`** (Optional): The length of time to run this specific scenario
+     (e.g., `"10m"`, `"300s"`). Defaults to `10m` if not specified.
+   - **`width` and `height`**: resolution of output images.
+   - **`steps`**: inference steps.
+
+   **Execution Workflow:** The k6 script automatically performs a **5-minute
+   warmup** using the first configured scenario's VU count to ensure the model
+   is loaded and compiled. Between each subsequent scenario, the script enforces
+   a **30-second cool-down period** to allow hardware metrics to return to
+   baseline for clean analysis.
+
+1. Source the environment configuration.
+
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
+
+### Destructive Testing & Stability
+
+When testing "frontier" configurations (e.g., Batch Size > 18 on RTX 6000),
+there is a high risk of triggering a **CUDA Out-of-Memory (OOM)** error. This
+will cause the inference server Pod to crash and restart.
+
+To ensure benchmark integrity, follow these stability guidelines:
+
+1. **Order Destructive Tests Last**: Always place scenarios that are likely to
+   crash the server at the very end of your `K6_SCENARIOS_JSON` array. This
+   prevents a crash from polluting the results of subsequent tests.
+1. **The Re-compilation Penalty**: The inference server uses `torch.compile`
+   with CUDA Graphs. If the server restarts due to an OOM, it requires **3-5
+   minutes** to re-warm and re-compile before it can achieve peak performance.
+1. **Recovery Warmups**: If you must run more tests after a potentially
+   destructive scenario in the same Job, insert a "Recovery Warmup" scenario
+   immediately after the risky one. A recovery scenario should use a small load
+   (e.g., `{"batch": 1, "vus": 1, "duration": "5m"}`) to give the server time to
+   restart and re-compile while k6 records the errors during the transition.
+
+### Tested Configurations Summary
+
+The following table illustrates the configurations that we tested serving
+`flux.2-klein-4b`, and which ones run the benchmark suite to completion,
+assuming no other load on the inference server.
+
+| Accelerator          | Backend | Resolution | Batch Size | VUs | Steps | Status   |
+| -------------------- | ------- | ---------- | ---------- | --- | ----- | -------- |
+| **NVIDIA L4**        | SGLang  | 1024x1024  | 1          | 1-4 | 20    | ✅       |
+| **NVIDIA L4**        | SGLang  | 1024x1024  | 2+         | 1   | 20    | ❌ (OOM) |
+| **NVIDIA L4**        | SGLang  | 768x768    | 1          | 1   | 20    | ✅       |
+| **NVIDIA L4**        | SGLang  | 512x512    | 1-4        | 1-4 | 10-20 | ✅       |
+| **NVIDIA L4 x2**     | SGLang  | 1024x1024  | 1          | 1-4 | 20    | ✅       |
+| **NVIDIA L4 x2**     | SGLang  | 1024x1024  | 2+         | 1   | 20    | ❌ (OOM) |
+| **NVIDIA L4 x2**     | SGLang  | 512x512    | 1          | 1   | 20    | ✅       |
+| **NVIDIA L4 x4**     | SGLang  | 1024x1024  | 1          | 1-2 | 20    | ✅       |
+| **NVIDIA L4 x4**     | SGLang  | 1024x1024  | 2+         | 1   | 20    | ❌ (OOM) |
+| **NVIDIA L4 x4**     | SGLang  | 512x512    | 1          | 1   | 20    | ✅       |
+| **RTX Pro 6000**     | SGLang  | 1024x1024  | 1-24       | 1-8 | 10-50 | ✅       |
+| **RTX Pro 6000**     | SGLang  | 512x512    | 1-4        | 1-4 | 10-20 | ✅       |
+| **RTX Pro 6000**     | SGLang  | 768x768    | 1          | 1   | 20    | ✅       |
+| **RTX Pro 6000 1/2** | SGLang  | 1024x1024  | 1-24       | 1-8 | 10-50 | ✅       |
+| **RTX Pro 6000 1/2** | SGLang  | 512x512    | 1-4        | 1-4 | 10-20 | ✅       |
+| **RTX Pro 6000 1/2** | SGLang  | 768x768    | 1          | 1   | 20    | ✅       |
+| **RTX Pro 6000 1/4** | SGLang  | 1024x1024  | 1-3        | 1-4 | 10-20 | ✅       |
+| **RTX Pro 6000 1/4** | SGLang  | 1024x1024  | 4+         | 1-8 | 10-20 | ❌ (OOM) |
+| **RTX Pro 6000 1/4** | SGLang  | 512x512    | 1-4        | 1-4 | 10-20 | ✅       |
+| **RTX Pro 6000 1/4** | SGLang  | 768x768    | 1          | 1   | 20    | ✅       |
+| **RTX Pro 6000 1/8** | SGLang  | All        | N/A        | N/A | N/A   | ❌ (OOM) |
+
+## Automated Execution (Recommended)
+
+You can use the provided orchestrator script to automate the entire lifecycle
+(build, deploy, monitor, and analyze) in a single command using the environment
+variables defined in the previous steps. The script supports running benchmarks
+sequentially across multiple accelerators by providing a comma-separated list:
+
+```shell
+# Example: Testing multiple resolutions and batch sizes in one run
+export ACCELERATOR_TYPE="l4,rtx-pro-6000"
+export K6_SCENARIOS_JSON='[
+  {"batch": 1, "vus": 1, "width": 512, "height": 512, "steps": 10},
+  {"batch": 4, "vus": 4, "width": 768, "height": 768, "steps": 20},
+  {"batch": 16, "vus": 1, "width": 1024, "height": 1024, "steps": 50}
+]'
+
+./platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/run_benchmark.sh \
+  --accelerator "${ACCELERATOR_TYPE}" \
+  --model "${HF_MODEL_ID}" \
+  --scenarios "${K6_SCENARIOS_JSON}" \
+  --build
+```
+
+**Script Flags:**
+
+- `--accelerator`: The accelerator type(s). Supports a single value (e.g., `l4`)
+  or a comma-separated list for sequential runs (e.g., `l4,rtx-pro-6000`).
+- `--model`: The Hugging Face model ID.
+- `--scenarios`: The JSON array of benchmark scenarios. Each scenario MUST
+  specify `batch`, `vus`, `width`, `height`, and `steps`.
+- `--build`: (Optional) Rebuild and push the k6 benchmark container image once
+  before starting the runs.
+- `--sync-only`: (Optional) Skip executing the benchmark workload on the
+  cluster, and jump straight to downloading the latest results from GCS and
+  running the data aggregation pipeline.
+- `--manual-cost`: (Optional) Override the default on-demand hourly price.
+
+## Manual Execution
+
+If you prefer to run the benchmarking steps individually, follow the
+instructions below.
+
+### Build the benchmark container image
+
+1. Source the environment configuration.
+
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
+
+1. Build the container image for the Diffusers inference server.
+
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   rm -rf ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/.terraform/ terraform.tfstate* && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark init && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark plan -input=false -out=tfplan && \
+   terraform -chdir=${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark apply -input=false tfplan && \
+   rm ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark/tfplan
+   ```
+
+   The build usually takes about 1 minute.
+
+### Deploy the benchmark workload
+
+1. Source the environment configuration.
+
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+   ```
+
+1. Set the benchmark parameters:
+
+   ```shell
+   export K6_SCENARIOS_JSON='[{"batch": 1, "vus": 1, "width": 1024, "height": 1024, "steps": 20}]'
+   ```
+
+1. Configure the deployment:
+
+   ```shell
+   source "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/configure_deployment.sh"
+   ```
+
+1. Deploy the benchmark workload.
+
+   ```shell
+   kubectl apply --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/${HF_MODEL_NAME}"
+   ```
+
+1. Watch the deployment until it is ready.
+
+   ```shell
+   watch --color --interval 5 --no-title \
+   "kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} get job/k6-benchmark-${HF_MODEL_NAME} | GREP_COLORS='mt=01;92' egrep --color=always -e '^' -e '1/1     1            1'
+   echo '\nLogs(last 10 lines):'
+   kubectl --namespace=${ira_online_gpu_kubernetes_namespace_name} logs job/k6-benchmark-${HF_MODEL_NAME} --all-containers --tail 10"
+   ```
+
+   When the deployment is ready, you will see the following:
+
+   ```text
+   NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
+   k6-benchmark-<HF_MODEL_NAME>                   1/1     1            1           ###
+   ```
+
+   You can press `CTRL`+`c` to terminate the watch.
+
+### Analyze and Interpret Results
+
+1. Download the files where the benchmarker collected data points:
+
+   ```shell
+     gcloud storage cp -r gs://${hub_models_bucket_bench_results_name}/ .
+   ```
+
+1. Set up the environment to run the metrics summarization script:
+
+   ```shell
+   # Create and activate a Python virtual environment
+   python3 -m venv .venv
+   . .venv/bin/activate
+
+   # Install dependencies
+   pip install --require-hashes -r "${ACP_REPO_DIR}/container-images/cpu/k6-benchmark/requirements.txt"
+   ```
+
+1. Set the hourly cost in USD for the Compute Engine machine you're using to run
+   the model by initializing the `MODEL_MACHINE_HOURLY_COST_USD` variable. For
+   example, if a machine costs `1.147208384` USD per hour, you initialize
+   `MODEL_MACHINE_HOURLY_COST_USD` as follows:
+
+   ```shell
+   export MODEL_MACHINE_HOURLY_COST_USD="1.147208384"
+   ```
+
+   For more information about machine pricing, see:
+
+   - [Accelerator-optimized pricing](https://cloud.google.com/products/compute/pricing/accelerator-optimized)
+
+1. Run the metrics aggregation and reporting script:
+
+   ```shell
+   for f in "${hub_models_bucket_bench_results_name}"/*"${HF_MODEL_NAME}"*"${ACCELERATOR_TYPE}"*.jsonl; do
+    echo "Processing $f..."
+    python3 "${ACP_REPO_DIR}/container-images/cpu/k6-benchmark/extract_metrics.py" \
+      --file "$f" \
+      --hourly-cost "${MODEL_MACHINE_HOURLY_COST_USD}" \
+      --project-id "${cluster_project_id}" \
+      --output-csv k6-benchmark.csv
+   done
+   ```
+
+1. Review aggregated results for each run by examining the contents of the
+   aggregated results files:
+
+   ```shell
+   for f in "${hub_models_bucket_bench_results_name}"/*report.txt; do
+     echo "Visualizing $f contents:"
+     cat "$f"
+   done
+   ```
+
+   The output is similar to the following:
+
+   ```text
+   ==================================================
+    GKE Performance Consolidated Report
+    Source: k6-diffusers-flux-2-klein-4b-rtx-pro-6000-20260422T123505Z.jsonl
+   ==================================================
+   SUMMARY TABLE:
+   Scenario             Img/s      Lat p50    GPU %      Cost/1k
+   ------------------------------------------------------------
+   bench_b1_v1          0.3779     2.648      84.95%     $3.3074
+   bench_b2_v4          0.4497     9.087      99.89%     $2.7798
+
+   --------------------------------------------------
+    SCENARIO: bench_b2_v4 (Batch: 2, VUs: 4)
+   --------------------------------------------------
+    UX Metrics: 0.4497 Img/s, 0.2248 RPS, Success: 100.00%
+    Latency (Req): p50=18.174s, p95=18.196s, p99=30.436s
+    Latency (Img): p50=9.087s, p95=9.098s, p99=15.218s
+    Hardware: VRAM=25984.0 MiB (26.43%), Compute=99.89%, Power=591.53 W
+    Economics: Cost/1k Images = $2.7798
+   ```
+
+1. Review the aggregated results across all runs:
+
+   ```shell
+   column -s, -t < k6-benchmark.csv | less -S
+   ```
+
+   The output is similar to the following:
+
+   ```text
+   Source File                                             Deployment Name               Target URL                               Model            Accelerator   Resolution  Inference Steps  Batch Size  VUs  Start Time (UTC)     End Time (UTC)       Total Time (s)  Total Requests  Throughput (Images/s)  Request Latency p50 (s)  Peak VRAM    Average Compute  Cost per 1k Images ($)
+   k6-diffusers-flux-2-klein-4b-rtx-pro-6000-20260421.jsonl  diffusers-rtx-pro-6000-flux   http://...                               flux-2-klein-4b  rtx-pro-6000  1024x1024   20               2           4    2026-04-22 12:40:28  2026-04-22 12:50:10  582.66          131             0.4497                 18.174                  25984.0 MiB  99.89%           2.7798
+   ```
+
+## Key LLM Performance Metrics Metric Description Optimization Focus
+
+- **_Time-to-First-Token (TTFT)_**: Latency from request start to the first
+  output token. Crucial for perceived responsiveness in chatbots.
+
+- **_Time-per-Output-Token (TPOT)_**: Average time to generate subsequent
+  tokens. Key measure of generation speed and sustained throughput.
+
+- **_Total Latency (P95/P99)_**: End-to-end time for the entire response.
+  Represents the experience of users with the slowest responses.
+
+- **_Throughput (Tokens/s)_**: Total tokens generated per second under load.
+  Measure of infrastructure efficiency and capacity.
+
+## Clean up
+
+1. Delete the benchmarking job.
+
+   ```shell
+   kubectl delete --ignore-not-found --kustomize "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/${HF_MODEL_NAME}"
+   ```
+
+1. Destroy the benchmarking resources.
+
+   > Note: This will only destroy your benchmarking results GCS bucket only if
+   > its empty
+
+   ```shell
+   export TF_PLUGIN_CACHE_DIR="${ACP_REPO_DIR}/.terraform.d/plugin-cache"
+   cd ${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench && \
+   rm -rf .terraform/ terraform.tfstate* && \
+   terraform init &&
+   terraform destroy -auto-approve
+   ```

--- a/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/run_benchmark.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/run_benchmark.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# --- Configuration & Discovery ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
+if [[ -z "${ACP_REPO_DIR:-}" ]]; then
+  ACP_REPO_DIR="$(cd "${SCRIPT_DIR}/../../../../../../" >/dev/null 2>&1 && pwd -P)"
+  export ACP_REPO_DIR
+fi
+
+ENV_SCRIPT="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
+if [[ -f "${ENV_SCRIPT}" ]]; then
+  echo "[INFO] Sourcing environment variables..."
+  source "${ENV_SCRIPT}"
+else
+  echo "[ERROR] Could not find environment script at ${ENV_SCRIPT}"
+  exit 1
+fi
+
+# --- Default Price Mapping (On-Demand) ---
+# Prices as of April 2026. Users should seek updated prices on:
+# https://cloud.google.com/products/compute/pricing
+function get_hourly_cost() {
+  case "$1" in
+  "l4") echo "1.147208384" ;;      # g2-standard-16 + 1x L4
+  "l4-x2") echo "2.000832696" ;;   # g2-standard-24 + 2x L4
+  "l4-x4") echo "4.001665392" ;;   # g2-standard-48 + 4x L4
+  "rtx-pro-6000") echo "4.4999" ;; # g4-standard-48 + 1x RTX 6000 (96GB)
+  "rtx-pro-6000-1-2") echo "2.5874425" ;; # g4-standard-24 + 1/2x RTX 6000
+  "rtx-pro-6000-1-4") echo "1.29372125" ;; # g4-standard-12 + 1/4x RTX 6000
+  "rtx-pro-6000-1-8") echo "0.646860625" ;; # g4-standard-6 + 1/8x RTX 6000
+  *) echo "0.0" ;;
+  esac
+}
+
+# --- CLI Arguments ---
+BUILD_IMAGE=false
+SYNC_ONLY=false
+SCENARIOS_JSON=""
+MANUAL_COST=""
+ACCELERATORS_INPUT=""
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+  --build) BUILD_IMAGE=true ;;
+  --sync-only) SYNC_ONLY=true ;;
+  --scenarios)
+    SCENARIOS_JSON="$2"
+    shift
+    ;;
+  --accelerator)
+    ACCELERATORS_INPUT="$2"
+    shift
+    ;;
+  --model)
+    export HF_MODEL_ID="$2"
+    shift
+    ;;
+  --manual-cost)
+    MANUAL_COST="$2"
+    shift
+    ;;
+  *)
+    echo "Unknown parameter: $1"
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [[ -z "${ACCELERATORS_INPUT}" ]]; then
+  echo "[ERROR] --accelerator is required (can be comma-separated list)"
+  exit 1
+fi
+if [[ -z "${HF_MODEL_ID}" ]]; then
+  echo "[ERROR] --model is required"
+  exit 1
+fi
+
+# Minify scenarios JSON and inject model_id to prevent Kustomize parsing errors
+if [[ "${SYNC_ONLY}" != "true" ]]; then
+  if [[ -z "${SCENARIOS_JSON}" ]]; then
+    SCENARIOS_JSON='[{"batch": 1, "vus": 1}]'
+  fi
+  export K6_SCENARIOS_JSON
+  K6_SCENARIOS_JSON=$(echo "${SCENARIOS_JSON}" | jq -c --arg m "${HF_MODEL_ID}" 'map(. + {model_id: $m})')
+fi
+
+# --- Phase 1: Build (Once) ---
+if [[ "${BUILD_IMAGE}" == "true" ]]; then
+  echo "[INFO] Building benchmark container image..."
+  cd "${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/images/cpu/k6_benchmark"
+  terraform init -input=false && terraform apply -auto-approve -input=false
+fi
+
+# --- Phase 2-5: Sequential Accelerator Loop ---
+IFS=',' read -ra ADDR <<<"${ACCELERATORS_INPUT}"
+for ACCEL in "${ADDR[@]}"; do
+  export ACCELERATOR_TYPE="${ACCEL}"
+  echo ""
+  echo "======================================================================"
+  echo " STARTING SUITE FOR ACCELERATOR: ${ACCELERATOR_TYPE}"
+  echo "======================================================================"
+
+  if [[ "${SYNC_ONLY}" != "true" ]]; then
+    # Refresh deployment config for this accelerator
+    echo "[INFO] Configuring deployment for ${HF_MODEL_NAME} on ${ACCELERATOR_TYPE}..."
+    CONFIG_DIR="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark"
+    pushd "${CONFIG_DIR}" >/dev/null
+    source "./configure_deployment.sh"
+    popd >/dev/null
+
+    echo "[INFO] Cleaning up existing benchmark jobs..."
+    kubectl delete --ignore-not-found --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+    kubectl wait --for=delete pod -l job-name="k6-benchmark-${HF_MODEL_NAME}" -n "${ira_online_gpu_kubernetes_namespace_name}" --timeout=60s || true
+
+    echo "[INFO] Launching benchmark Job..."
+    kubectl apply --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+
+    # --- Phase 4: Monitoring ---
+    echo "[INFO] Monitoring benchmark Job..."
+
+    LOG_PID=""
+
+    # Smart Monitoring Loop
+    (while true; do
+      # Get current Pod name and status
+      POD_INFO=$(kubectl get pods -n "${ira_online_gpu_kubernetes_namespace_name}" -l job-name="k6-benchmark-${HF_MODEL_NAME}" -o jsonpath='{.items[0].metadata.name} {.items[0].status.phase}' 2>/dev/null || echo "None None")
+      read -r POD_NAME POD_STATUS <<<"$POD_INFO"
+
+      TIMESTAMP=$(date +"%T")
+
+      if [[ "${POD_STATUS}" == "Running" ]]; then
+        # If Pod is running but we aren't tailing logs yet, start tailing
+        if [[ -z "${LOG_PID}" ]] || ! kill -0 "${LOG_PID}" 2>/dev/null; then
+          echo "[${TIMESTAMP}] Pod is Running. Starting log stream..."
+          kubectl logs -n "${ira_online_gpu_kubernetes_namespace_name}" "${POD_NAME}" -c k6-benchmark -f &
+          LOG_PID=$!
+        fi
+        echo "[HEARTBEAT] ${TIMESTAMP} | Pod: ${POD_NAME} | Status: ${POD_STATUS}"
+      elif [[ "${POD_STATUS}" == "Pending" ]]; then
+        # If pending, show the latest event to track scale-up/image pull
+        EVENT=$(kubectl get events -n "${ira_online_gpu_kubernetes_namespace_name}" --field-selector involvedObject.name="${POD_NAME}" --sort-by='.lastTimestamp' -o jsonpath='{.items[-1].message}' 2>/dev/null || echo "Waiting for events...")
+        echo "[HEARTBEAT] ${TIMESTAMP} | Status: Pending | Last Event: ${EVENT}"
+      elif [[ "${POD_STATUS}" == "None" ]]; then
+        echo "[HEARTBEAT] ${TIMESTAMP} | Waiting for Pod to be created..."
+      else
+        echo "[HEARTBEAT] ${TIMESTAMP} | Status: ${POD_STATUS}"
+      fi
+
+      sleep 60
+    done) &
+    MONITOR_PID=$!
+
+    echo "[INFO] Waiting for Job completion (max 6h)..."
+    TIMEOUT=21600 # 6 hours
+    ELAPSED=0
+    SLEEP_INTERVAL=10
+    while true; do
+      # Check terminal state
+      STATUS=$(kubectl get job "k6-benchmark-${HF_MODEL_NAME}" -n "${ira_online_gpu_kubernetes_namespace_name}" -o jsonpath='{.status.conditions[?(@.status=="True")].type}' 2>/dev/null || echo "Unknown")
+
+      if [[ "$STATUS" == *"Complete"* ]]; then
+        echo "[INFO] Job completed successfully."
+        break
+      elif [[ "$STATUS" == *"Failed"* ]]; then
+        echo "[ERROR] Job failed or was aborted by k6 thresholds. Check container logs for details."
+        break
+      elif [[ "$STATUS" == "Unknown" ]]; then
+        if ! kubectl get job "k6-benchmark-${HF_MODEL_NAME}" -n "${ira_online_gpu_kubernetes_namespace_name}" &>/dev/null; then
+          echo "[WARN] Job not found. Stopping wait."
+          break
+        fi
+      fi
+
+      if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+        echo "[ERROR] Timeout reached waiting for Job completion."
+        exit 1
+      fi
+
+      sleep $SLEEP_INTERVAL
+      ELAPSED=$((ELAPSED + SLEEP_INTERVAL))
+    done
+
+    kill $MONITOR_PID 2>/dev/null || true
+    # Ensure the background log process (inside the monitor subshell) is also cleaned up
+    # We kill the process group to be sure
+    pkill -P $MONITOR_PID 2>/dev/null || true
+  else
+    echo "[INFO] --sync-only flag detected. Skipping Job deployment and monitoring."
+  fi
+
+  echo "[INFO] Syncing results from GCS..."
+  RESULTS_DIR="${ACP_REPO_DIR}/${hub_models_bucket_bench_results_name}"
+  mkdir -p "${RESULTS_DIR}"
+  gcloud storage cp -r "gs://${hub_models_bucket_bench_results_name}/*.jsonl" "${RESULTS_DIR}/"
+
+  # Find the most recent file for this SPECIFIC accelerator run
+  LATEST_JSONL=$(ls -t "${RESULTS_DIR}"/*"${HF_MODEL_NAME}"*"${ACCELERATOR_TYPE}"*.jsonl | head -n 1)
+  COST="${MANUAL_COST:-$(get_hourly_cost "${ACCELERATOR_TYPE}")}"
+
+  echo "[INFO] ----------------------------------------------------------------------"
+  echo "[INFO] Analyzing: ${LATEST_JSONL}"
+  echo "[INFO] Accelerator: ${ACCELERATOR_TYPE} | Cost: \$${COST}/hr"
+  echo "[INFO] DISCLAIMER: This rate represents public on-demand pricing."
+  echo "[INFO] It does NOT account for CUDs, SUDs, or custom private pricing."
+  echo "[INFO] For current and accurate pricing, visit:"
+  echo "[INFO] https://cloud.google.com/products/compute/pricing"
+  echo "[INFO] ----------------------------------------------------------------------"
+
+  . "${ACP_REPO_DIR}/.venv/bin/activate"
+  python3 "${ACP_REPO_DIR}/container-images/cpu/k6-benchmark/extract_metrics.py" \
+    --file "${LATEST_JSONL}" \
+    --hourly-cost "${COST}" \
+    --project-id "${cluster_project_id}" \
+    --namespace "${ira_online_gpu_kubernetes_namespace_name}" \
+    --output-csv "${ACP_REPO_DIR}/k6-benchmark.csv"
+
+  if [[ "${SYNC_ONLY}" != "true" ]]; then
+    echo "[INFO] Cleaning up Job resources for ${ACCELERATOR_TYPE}..."
+    kubectl delete --ignore-not-found --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+  fi
+done
+
+echo ""
+echo "======================================================================"
+echo " ALL BENCHMARK SUITES COMPLETE"
+echo " Final Aggregated CSV: ${ACP_REPO_DIR}/k6-benchmark.csv"
+echo "======================================================================"

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/kustomization.yaml
@@ -1,0 +1,86 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - envs:
+      - runtime.env
+    name: runtime
+    namespace: replaced-by-kustomize
+
+nameSuffix: -flux-2-klein-4b
+
+patches:
+  - path: patch-nodeselector.yaml
+  - path: patch-resources.yaml
+
+replacements:
+  - source:
+      fieldPath: data.APP_LABEL
+      kind: ConfigMap
+      name: runtime
+    targets:
+      - fieldPaths:
+          - spec.template.metadata.labels.app
+        select:
+          kind: Job
+  - source:
+      fieldPath: data.CONTAINER_IMAGE_URL
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.[name=k6-benchmark].image
+        select:
+          kind: Job
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_NAMESPACE
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: ConfigMap
+      - fieldPaths:
+          - metadata.namespace
+        select:
+          kind: Job
+  - source:
+      fieldPath: data.INFERENCE_KUBERNETES_SERVICE_ACCOUNT
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.serviceAccountName
+        select:
+          kind: Job
+      - fieldPaths:
+          - metadata.name
+        select:
+          kind: ServiceAccount
+  - source:
+      fieldPath: data.BENCHMARK_RESULTS_BUCKET_NAME
+      kind: ConfigMap
+      name: deployment
+    targets:
+      - fieldPaths:
+          - spec.template.spec.volumes.[name=k6-benchmark-bucket-results].csi.volumeAttributes.bucketName
+        select:
+          kind: Job
+
+resources:
+  - ../base

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/patch-nodeselector.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/patch-nodeselector.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k6-benchmark
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/compute-class: cpu-n4-8

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/patch-resources.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/patch-resources.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k6-benchmark
+  namespace: replaced-by-kustomize
+spec:
+  template:
+    spec:
+      containers:
+        - name: k6-benchmark
+          args:
+            - "/app/scripts/k6-diffusers-flux-2-klein-4b.js"
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1G
+            requests:
+              cpu: "2"
+              memory: 1G

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/runtime.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/k6-benchmark/flux-2-klein-4b/runtime.env
@@ -1,0 +1,1 @@
+APP_LABEL=k6-benchmark-flux-2-klein-4b


### PR DESCRIPTION
Implement a k6 benchmark for flux.2

The benchmark uses k6 to configure virtual users that send requests to a backend running SGLang that serves `flux.2-klein-4B`.

An orchestration script takes care of running the benchmark, but there's also guidance to manually run individual test runs.

The benchmark Pod runs on a CPU-only machine because it doesn't need any accelerator.