### PR TITLE
chore: bump terraform versions

### DIFF
--- a/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
+++ b/platforms/gke/base/core/gke_enterprise/policycontroller/feature.tf
@@ -89,7 +89,7 @@ module "kubectl_wait_gatekeeper_controller" {
   resource         = "pod"
   retry_on_failure = true
   selector         = "control-plane=controller-manager"
-  timeout          = "300s"
+  timeout          = "900s"
   wait_for_create  = true
 }
 

--- a/platforms/gke/base/core/workloads/storage_class/versions.tf
+++ b/platforms/gke/base/core/workloads/storage_class/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.6.0"
+      version = "7.39.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This PR bumps the Terraform Google Provider version from 7.6.0 to 7.39.0 in support of newer features for example the ones required for fast startup and scaling of Inference deployments.