### PR TITLE
fix: use portable bash shebang

### DIFF
--- a/platforms/cws/_shared_config/scripts/apply_profile.sh
+++ b/platforms/cws/_shared_config/scripts/apply_profile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/cws/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/cws/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/cws/cluster/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/cws/cluster/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/cws/image_pipeline/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/cws/image_pipeline/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/cws/workstation_configurations/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/cws/workstation_configurations/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/cluster_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/cluster_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/cluster_namespace_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/cluster_namespace_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/gateway_cleanup.sh
+++ b/platforms/gke-aiml/playground/scripts/gateway_cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/gateway_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/gateway_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/git_cred_secret.sh
+++ b/platforms/gke-aiml/playground/scripts/git_cred_secret.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/add_to_kustomization.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/add_to_kustomization.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/clone_git_repo.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/clone_git_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/generate_oic_image.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/generate_oic_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/git_config_env.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/git_config_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/wait_for_repo_sync.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/wait_for_repo_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/helpers/wait_for_root_sync.sh
+++ b/platforms/gke-aiml/playground/scripts/helpers/wait_for_root_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/kuberay_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/kuberay_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/kuberay_watch_namespace_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/kuberay_watch_namespace_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/kueue_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/kueue_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/namespace_cleanup.sh
+++ b/platforms/gke-aiml/playground/scripts/namespace_cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/namespace_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/namespace_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/nvidia_dcgm_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/nvidia_dcgm_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/synchronize_configsync.sh
+++ b/platforms/gke-aiml/playground/scripts/synchronize_configsync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/template_manifests.sh
+++ b/platforms/gke-aiml/playground/scripts/template_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke-aiml/playground/scripts/wait_for_configsync.sh
+++ b/platforms/gke-aiml/playground/scripts/wait_for_configsync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/_shared_config/scripts/configuration_from_gcs.sh
+++ b/platforms/gke/base/_shared_config/scripts/configuration_from_gcs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/_shared_config/scripts/configuration_to_gcs.sh
+++ b/platforms/gke/base/_shared_config/scripts/configuration_to_gcs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/_shared_config/scripts/link_shared_config.sh
+++ b/platforms/gke/base/_shared_config/scripts/link_shared_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/deploy-ap.sh
+++ b/platforms/gke/base/core/deploy-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/deploy-standard.sh
+++ b/platforms/gke/base/core/deploy-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/deploy.sh
+++ b/platforms/gke/base/core/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/core/functions.sh
+++ b/platforms/gke/base/core/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/teardown-ap.sh
+++ b/platforms/gke/base/core/teardown-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/teardown-standard.sh
+++ b/platforms/gke/base/core/teardown-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/platforms/gke/base/core/teardown.sh
+++ b/platforms/gke/base/core/teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-gpu-model/deploy-ap.sh
+++ b/platforms/gke/base/tutorials/hf-gpu-model/deploy-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-gpu-model/deploy-standard.sh
+++ b/platforms/gke/base/tutorials/hf-gpu-model/deploy-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-gpu-model/teardown-ap.sh
+++ b/platforms/gke/base/tutorials/hf-gpu-model/teardown-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-gpu-model/teardown-standard.sh
+++ b/platforms/gke/base/tutorials/hf-gpu-model/teardown-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-tpu-model/deploy-ap.sh
+++ b/platforms/gke/base/tutorials/hf-tpu-model/deploy-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-tpu-model/deploy-standard.sh
+++ b/platforms/gke/base/tutorials/hf-tpu-model/deploy-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-tpu-model/teardown-ap.sh
+++ b/platforms/gke/base/tutorials/hf-tpu-model/teardown-ap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/tutorials/hf-tpu-model/teardown-standard.sh
+++ b/platforms/gke/base/tutorials/hf-tpu-model/teardown-standard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/platforms/gke/base/use-cases/reinforcement-learning/terraform/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/use-cases/reinforcement-learning/terraform/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2026 Google LLC
 #

--- a/platforms/gke/base/use-cases/training-ref-arch/_shared_config/scripts/set_environment_variables.sh
+++ b/platforms/gke/base/use-cases/training-ref-arch/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2025 Google LLC
 #

--- a/terraform/modules/config_controller/scripts/gcloud_create.sh
+++ b/terraform/modules/config_controller/scripts/gcloud_create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/terraform/modules/config_controller/scripts/gcloud_delete.sh
+++ b/terraform/modules/config_controller/scripts/gcloud_delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/test/ci-cd/scripts/platforms/gke/base/core/ap-full-deploy.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/core/ap-full-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/test/ci-cd/scripts/platforms/gke/base/core/ap-full-teardown.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/core/ap-full-teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/test/ci-cd/scripts/platforms/gke/base/core/standard-full-deploy.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/core/standard-full-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/test/ci-cd/scripts/platforms/gke/base/core/standard-full-teardown.sh
+++ b/test/ci-cd/scripts/platforms/gke/base/core/standard-full-teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #

--- a/test/ci-cd/terraform/_shared_config/scripts/set_environment_variables.sh
+++ b/test/ci-cd/terraform/_shared_config/scripts/set_environment_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 Google LLC
 #


### PR DESCRIPTION
Use `#!/usr/bin/env bash` instead of `#!/bin/bash` so the scripts resolve bash from `PATH`.

Improves portability to platforms such as macOS and NixOS. The other 197 bash scripts in the repo already use this form.

Shebang line only; no script bodies or file modes changed.