### PR TITLE
fix: correct llmd_model_id for Gemma to gemma-4-31b-it

### DIFF
--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/llmd-vllm-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/llmd-vllm-with-hf-model.md
@@ -116,7 +116,7 @@ precedence over earlier ones:
 
   Valid values for `MODEL_ID` are:
 
-  - `google/gemma-4-32b-it`
+  - `google/gemma-4-31b-it`
   - `qwen/qwen3-32b` **(default)**
 
 - In order to choose an accelerator and for the model you want to run, refer to
@@ -124,7 +124,7 @@ precedence over earlier ones:
 
   |     Model      | h100 | h200 | RTX Pro 6000 |
   | :------------: | :--: | :--: | :----------: |
-  | gemma-4-32b-it |  ✅  |  ✅  |      ✅      |
+  | gemma-4-31b-it |  ✅  |  ✅  |      ✅      |
   |   qwen3-32b    |  ✅  |  ✅  |      ✅      |
 
 - Optional : Run the following step if you want to run the model on an

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-shared_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-shared_variables.tf
@@ -46,7 +46,7 @@ variable "llmd_model_id" {
   validation {
     condition = contains(
       [
-        "google/gemma-4-32b-it",
+        "google/gemma-4-31b-it",
         "qwen/qwen3-32b",
       ],
       var.llmd_model_id


### PR DESCRIPTION
## Problem

The `llmd_model_id` validation rule accepts only `google/gemma-4-32b-it`, which is not a model that exists.

The `google` organization on Hugging Face publishes Gemma 4 in **12B**, **26B-A4B** and **31B** sizes (plus the `E2B`/`E4B` efficiency variants). There is no 32B. `google/gemma-4-31b-it` resolves to a live model (`Gemma4ForConditionalGeneration`, Apache-2.0); `google/gemma-4-32b-it` does not resolve.

This makes Gemma unreachable through this path entirely:

- `google/gemma-4-31b-it` — rejected by the validation rule.
- `google/gemma-4-32b-it` — passes validation, then fails later. `set_environment_variables.sh` derives `HF_MODEL_NAME` from the model id, and no `<accelerator>-gemma-4-32b-it` Kustomize overlay exists.

## Fix

Point the validation rule at `google/gemma-4-31b-it`, and update the one remaining doc reference.

Every other reference in the repository already uses `gemma-4-31b-it` — the vLLM overlays for `h100`, `h200`, `rtx-pro-6000` and `v6e` under both `online-inference-gpu/` and `online-inference-tpu/`, the per-guide `runtime.env` files, and the well-lit-path guides. Only the validation rule and `llmd-vllm-with-hf-model.md` were out of step.

## Verification

- `google/gemma-4-31b-it` now passes validation, and `HF_MODEL_NAME` resolves to the existing overlay `online-inference-gpu/llmd-optimized-baseline/vllm/h100-gemma-4-31b-it`.
- `grep -rn "gemma-4-32b"` returns no results across the repository.