### PR TITLE
removing inferencegateway terraservice from llmd well-lit path deployment

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-optimized-baseline.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-optimized-baseline.sh
@@ -60,7 +60,6 @@ declare -a CORE_TERRASERVICES_APPLY=(
   "custom_compute_class"
   "workloads/auto_monitoring"
   "workloads/custom_metrics_adapter"
-  "workloads/inference_gateway"
   "workloads/priority_class"
 )
 CORE_TERRASERVICES_APPLY="${CORE_TERRASERVICES_APPLY[*]}" "${ACP_PLATFORM_CORE_DIR}/deploy.sh"

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-precise-prefix-cache-routing.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-precise-prefix-cache-routing.sh
@@ -60,7 +60,6 @@ declare -a CORE_TERRASERVICES_APPLY=(
   "custom_compute_class"
   "workloads/auto_monitoring"
   "workloads/custom_metrics_adapter"
-  "workloads/inference_gateway"
   "workloads/priority_class"
 )
 CORE_TERRASERVICES_APPLY="${CORE_TERRASERVICES_APPLY[*]}" "${ACP_PLATFORM_CORE_DIR}/deploy.sh"

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-predicted-latency-routing.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/deploy-llmd-predicted-latency-routing.sh
@@ -60,7 +60,6 @@ declare -a CORE_TERRASERVICES_APPLY=(
   "custom_compute_class"
   "workloads/auto_monitoring"
   "workloads/custom_metrics_adapter"
-  "workloads/inference_gateway"
   "workloads/priority_class"
 )
 CORE_TERRASERVICES_APPLY="${CORE_TERRASERVICES_APPLY[*]}" "${ACP_PLATFORM_CORE_DIR}/deploy.sh"

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-optimized-baseline.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-optimized-baseline.sh
@@ -79,7 +79,6 @@ done
 if [ "${ACP_TEARDOWN_CORE_PLATFORM}" = "true" ]; then
   declare -a CORE_TERRASERVICES_DESTROY=(
     "workloads/priority_class"
-    "workloads/inference_gateway"
     "workloads/custom_metrics_adapter"
     "workloads/auto_monitoring"
     "custom_compute_class"

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-precise-prefix-cache-routing.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-precise-prefix-cache-routing.sh
@@ -79,7 +79,6 @@ done
 if [ "${ACP_TEARDOWN_CORE_PLATFORM}" = "true" ]; then
   declare -a CORE_TERRASERVICES_DESTROY=(
     "workloads/priority_class"
-    "workloads/inference_gateway"
     "workloads/custom_metrics_adapter"
     "workloads/auto_monitoring"
     "custom_compute_class"

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-predicted-latency-routing.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/teardown-llmd-predicted-latency-routing.sh
@@ -79,7 +79,6 @@ done
 if [ "${ACP_TEARDOWN_CORE_PLATFORM}" = "true" ]; then
   declare -a CORE_TERRASERVICES_DESTROY=(
     "workloads/priority_class"
-    "workloads/inference_gateway"
     "workloads/custom_metrics_adapter"
     "workloads/auto_monitoring"
     "custom_compute_class"


### PR DESCRIPTION
The inference gateway terraservice is not needed as GKE version 1.32 and above by default provide it.