### PR TITLE
docs: RedHatAI gemma-4-31B-it-FP8-block is not supported on TPU v6e

### DIFF
--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-optimized-baseline-vllm-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-optimized-baseline-vllm-with-hf-model.md
@@ -113,7 +113,7 @@ precedence over earlier ones:
   |          gemma-4-31b-it           |    ✅     |    ✅     |        ✅         |    ✅    |
   |             qwen3-32b             |    ✅     |    ✅     |        ✅         |    ✅    |
   |        Qwen/Qwen3-32B-FP8         |    ✅     |    ❌     |        ✅         |    ✅    |
-  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ✅    |
+  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ❌    |
 
 - Optional : Run the following step if you want to run the model on an
   accelerator other than `nvidia-rtx-pro` which is the default accelerator for

--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-precise-prefix-cache-routing-vllm-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-precise-prefix-cache-routing-vllm-with-hf-model.md
@@ -114,7 +114,7 @@ precedence over earlier ones:
   |          gemma-4-31b-it           |    ✅     |    ✅     |        ✅         |    ✅    |
   |             qwen3-32b             |    ✅     |    ✅     |        ✅         |    ✅    |
   |        Qwen/Qwen3-32B-FP8         |    ✅     |    ❌     |        ✅         |    ✅    |
-  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ✅    |
+  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ❌    |
 
 - Optional : Run the following step if you want to run the model on an
   accelerator other than `nvidia-rtx-pro` which is the default accelerator for

--- a/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-predicted-latency-routing-vllm-with-hf-model.md
+++ b/docs/platforms/gke/base/use-cases/inference-ref-arch/llmd/well-lit-paths/llmd-predicted-latency-routing-vllm-with-hf-model.md
@@ -113,7 +113,7 @@ precedence over earlier ones:
   |          gemma-4-31b-it           |    ✅     |    ✅     |        ✅         |    ✅    |
   |             qwen3-32b             |    ✅     |    ✅     |        ✅         |    ✅    |
   |        Qwen/Qwen3-32B-FP8         |    ✅     |    ❌     |        ✅         |    ✅    |
-  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ✅    |
+  | RedHatAI/gemma-4-31B-it-FP8-block |    ✅     |    ❌     |        ✅         |    ❌    |
 
 - Optional : Run the following step if you want to run the model on an
   accelerator other than `nvidia-rtx-pro` which is the default accelerator for


### PR DESCRIPTION
The model/accelerator table marks `RedHatAI/gemma-4-31B-it-FP8-block` as supported on TPU(v6e), but it cannot load there.

It is quantized with `compressed-tensors` (`FP8_BLOCK`, `format: float-quantized`), and the TPU JAX backend in `vllm/vllm-tpu:v0.22.0` only accepts `[None, 'fp8']`:

```
File "/workspace/tpu_inference/tpu_inference/layers/jax/quantization/__init__.py", line 37,
  in get_tpu_quantization_config
    raise NotImplementedError(
NotImplementedError: compressed-tensors quantization method not supported.
Supported methods are dict_keys([None, 'fp8'])
```

Reproduced on 2 x ct6e-standard-4t (TP=4) with the `v6e-gemma-4-31b-it-fp8-block` overlay: both replicas CrashLoopBackOff at engine init.

The `Qwen/Qwen3-32B-FP8` row is left as-is — that model uses `quant_method: fp8` and is genuinely supported on v6e. Only the RedHat row changes.