### PR TITLE
fix: add input_tps column to benchmark CSV

### DIFF
--- a/skills/llm-d-benchmarking/scripts/extract_csv.py
+++ b/skills/llm-d-benchmarking/scripts/extract_csv.py
@@ -32,6 +32,7 @@ REQ_PRE = "results.request_performance.aggregate"
 SES_PRE = "results.session_performance.sessions"
 
 _METRICS_RAW = {
+    "input_tps": f"{REQ_PRE}.throughput.input_token_rate.mean",
     "output_tps": f"{REQ_PRE}.throughput.output_token_rate.mean",
     "request_qps": f"{REQ_PRE}.throughput.request_rate.mean",
     "total_tps": f"{REQ_PRE}.throughput.total_token_rate.mean",


### PR DESCRIPTION
The CSV summary emits `output_tps` and `total_tps` but omits input throughput, so prefill-heavy runs appear nearly idle.

Measured on an `agentic_code_generation` run (gemma-4-31b-it, TPU v6e, 2 x ct6e-standard-8t, TP=8), input throughput is ~36x output:

```
input_tps  = 7372.65
output_tps =  205.68
total_tps  = 7578.33
```

At concurrency 40 the gap is wider still: 11,795 vs 316 tokens/s.

One line added to `_METRICS_RAW`. Note this depends on `input_token_rate` being present in the v0.2 report — filed upstream as llm-d/llm-d-benchmark#1713; until that merges the column will be blank rather than wrong.