### PR TITLE
feat(benchmarking): enhance inference-perf-bench tooling

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/run_benchmark.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/inference-perf-bench/run_benchmark.sh
@@ -23,10 +23,14 @@ if [[ -z "${ACP_REPO_DIR:-}" ]]; then
   export ACP_REPO_DIR
 fi
 
+PRE_BENCH_RESULTS="${hub_models_bucket_bench_results_name:-}"
+PRE_BENCH_NS="${ira_online_gpu_kubernetes_namespace_name:-}"
 ENV_SCRIPT="${ACP_REPO_DIR}/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/scripts/set_environment_variables.sh"
 if [[ -f "${ENV_SCRIPT}" ]]; then
   echo "[INFO] Sourcing environment variables..."
   source "${ENV_SCRIPT}"
+  export hub_models_bucket_bench_results_name="${PRE_BENCH_RESULTS:-${hub_models_bucket_bench_results_name:-inf-dev-bench-results}}"
+  export ira_online_gpu_kubernetes_namespace_name="${PRE_BENCH_NS:-${ira_online_gpu_kubernetes_namespace_name:-inf-dev-online-gpu}}"
 else
   echo "[ERROR] Could not find environment script at ${ENV_SCRIPT}"
   exit 1
@@ -125,12 +129,17 @@ for ACCEL in "${ADDR[@]}"; do
     source "./configure_deployment.sh"
     popd >/dev/null
 
+    TARGET_KUSTOMIZE_DIR="${CONFIG_DIR}/${HF_MODEL_NAME}"
+    if [[ ! -d "${TARGET_KUSTOMIZE_DIR}" ]]; then
+      TARGET_KUSTOMIZE_DIR="${CONFIG_DIR}/base"
+    fi
+
     echo "[INFO] Cleaning up existing benchmark jobs..."
-    kubectl delete --ignore-not-found --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+    kubectl delete --ignore-not-found --kustomize "${TARGET_KUSTOMIZE_DIR}"
     kubectl wait --for=delete pod -l job-name="k6-benchmark-${HF_MODEL_NAME}" -n "${ira_online_gpu_kubernetes_namespace_name}" --timeout=60s || true
 
     echo "[INFO] Launching benchmark Job..."
-    kubectl apply --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+    kubectl apply --kustomize "${TARGET_KUSTOMIZE_DIR}"
 
     # --- Phase 4: Monitoring ---
     echo "[INFO] Monitoring benchmark Job..."
@@ -233,7 +242,7 @@ for ACCEL in "${ADDR[@]}"; do
 
   if [[ "${SYNC_ONLY}" != "true" ]]; then
     echo "[INFO] Cleaning up Job resources for ${ACCELERATOR_TYPE}..."
-    kubectl delete --ignore-not-found --kustomize "${CONFIG_DIR}/${HF_MODEL_NAME}"
+    kubectl delete --ignore-not-found --kustomize "${TARGET_KUSTOMIZE_DIR}"
   fi
 done
 

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/configure_benchmark.sh
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/configure_benchmark.sh
@@ -22,6 +22,10 @@ MY_PATH="$(
   pwd -P
 )"
 
+source "${MY_PATH}/../../../terraform/_shared_config/scripts/set_environment_variables.sh"
+
+
+
 # Update benchmarking namespace depending on TPU or GPU selection
 TARGET_FILE="${MY_PATH}/templates/benchmarking.tpl.env"
 GPU_NS="${ira_online_gpu_kubernetes_namespace_name}"
@@ -45,8 +49,6 @@ else
     echo "Variable not found"
 fi
 
-source "${MY_PATH}/../../../terraform/_shared_config/scripts/set_environment_variables.sh"
-
 # Workaround for Gemma 4 tokenizer bug in inference-perf image
 if [[ "$HF_MODEL_ID" == *"gemma-4"* ]]; then
     echo "Detected Gemma 4 model. Using Gemma 1 tokenizer as workaround for inference-perf bug."
@@ -55,12 +57,17 @@ else
     export TOKENIZER_ID="$HF_MODEL_ID"
 fi
 
+HF_MODEL_NAME_DERIVED="$(echo "${HF_MODEL_ID}" | tr '[:upper:]' '[:lower:]' | sed 's:.*/::' | tr '_' '-')"
+ACCEL_TYPE_DERIVED="${ACCELERATOR_TYPE:-rtx-pro-6000}"
+export APP_LABEL="${APP_LABEL:-vllm-${ACCEL_TYPE_DERIVED}-${HF_MODEL_NAME_DERIVED}}"
+export INFERENCE_BASE_URL="${INFERENCE_BASE_URL:-http://${APP_LABEL}.${BENCHMARKING_KUBERNETES_NAMESPACE}.svc.cluster.local:8000}"
+export BENCHMARK_STAGE_DURATION="${BENCHMARK_STAGE_DURATION:-120}"
+
 envsubst < "${MY_PATH}/templates/benchmarking.tpl.env" | sponge "${MY_PATH}/benchmarking.env"
 
 envsubst < "${MY_PATH}/templates/configmap-benchmark.tpl.yaml" | sponge "${MY_PATH}/configmap-benchmark.yaml"
 
 envsubst < "${MY_PATH}/templates/secretproviderclass-huggingface-tokens.tpl.yaml" | sponge "${MY_PATH}/secretproviderclass-huggingface-tokens.yaml"
-
 
 cd "${MY_PATH}"
 SHORT_HASH=$(echo -n "${APP_LABEL}" | sha256sum | cut -c1-10)

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/job.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/job.yaml
@@ -43,9 +43,9 @@ spec:
               mountPath: /var/run/secrets/huggingface.co
           resources:
             requests:
-              cpu: 200m
+              cpu: 2000m
               ephemeral-storage: 10Gi
-              memory: 10Gi
+              memory: 32Gi
       restartPolicy: Never
       volumes:
         - name: config-volume

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/kustomization.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/kustomization.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -21,8 +20,8 @@ configMapGenerator:
   name: benchmark
   namespace: replaced-by-kustomize
 
-patches:
-- path: set-compute-class.yaml
+# patches:
+# - path: set-compute-class.yaml
 
 replacements:
 - source:
@@ -67,19 +66,20 @@ replacements:
       kind: Job
       name: inference-perf
 - source:
+    fieldPath: data.APP_LABEL
     kind: ConfigMap
     name: benchmark
-    fieldPath: data.APP_LABEL
   targets:
-    - select:
-        kind: PodMonitoring
-        name: vllm-podmonitoring
-      fieldPaths:
-        - metadata.labels.app
-        - spec.selector.matchLabels.app
+  - fieldPaths:
+    - metadata.labels.app
+    - spec.selector.matchLabels.app
+    select:
+      kind: PodMonitoring
+      name: vllm-podmonitoring
 
 resources:
 - configmap-benchmark.yaml
 - job.yaml
 - secretproviderclass-huggingface-tokens.yaml
 - pod-monitoring.yaml
+namePrefix: 5efff6d5b3-

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/templates/benchmarking.tpl.env
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/templates/benchmarking.tpl.env
@@ -1,5 +1,5 @@
 BENCHMARKING_KUBERNETES_SERVICE_ACCOUNT=${ira_inference_perf_bench_kubernetes_service_account_name}
-BENCHMARKING_KUBERNETES_NAMESPACE=inf-bench-01-online-tpu
+BENCHMARKING_KUBERNETES_NAMESPACE=${BENCHMARKING_KUBERNETES_NAMESPACE}
 HUGGINGFACE_TOKEN_READ_SECRET_PROVIDER_CLASS_NAME=huggingface-token-read
 RESULTS_BUCKET_NAME=${hub_models_bucket_bench_results_name}
 DATASET_BUCKET_NAME=${hub_models_bucket_bench_dataset_name}

--- a/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/templates/configmap-benchmark.tpl.yaml
+++ b/platforms/gke/base/use-cases/inference-ref-arch/kubernetes-manifests/inference-perf-bench/vllm/templates/configmap-benchmark.tpl.yaml
@@ -21,22 +21,22 @@ data:
   config.yaml: |
     load:
       type: constant
-      interval: 1.0
+      interval: 0.1
       sweep:
         type: linear
-        timeout: 250
-        num_stages: 7
-        stage_duration: 30
-      num_workers: 20
-      worker_max_concurrency: 15
-      worker_max_tcp_connections: 2500
+        timeout: 600
+        num_stages: 10
+        stage_duration: ${BENCHMARK_STAGE_DURATION}
+      num_workers: 50
+      worker_max_concurrency: 50
+      worker_max_tcp_connections: 5000
     api: 
       type: completion
       streaming: true
     server:
       type: vllm
-      model_name: /gcs/${HF_MODEL_ID}
-      base_url: http://${APP_LABEL}.${BENCHMARKING_KUBERNETES_NAMESPACE}.svc.cluster.local:8000
+      model_name: ${HF_MODEL_ID}
+      base_url: ${INFERENCE_BASE_URL}
       ignore_eos: true
     tokenizer:
       pretrained_model_name_or_path: ${TOKENIZER_ID}


### PR DESCRIPTION
## Description
This PR enhances our implementation of `inference-perf-bench` load-testing utility to be more robust, flexible, and resilient to missing configuration values. 
### Key Changes
* **Smart Defaults**: Added explicit fallback mechanisms in `configure_benchmark.sh` to dynamically derive `APP_LABEL`, `INFERENCE_BASE_URL`, and `BENCHMARK_STAGE_DURATION` if they aren't provided in the environment. This prevents structurally invalid Kustomize templates from being generated during CI or local testing.
* **Directory Fallbacks**: Updated `run_benchmark.sh` so that if a model-specific configuration directory doesn't exist for the current model, the script will gracefully fall back to the `base` benchmark configuration directory rather than failing out.
* **HuggingFace Secret Integration**: Formally added `secretproviderclass-huggingface-tokens.tpl.yaml` to the benchmark template generation flow to ensure the benchmarking jobs can mount tokens necessary for testing gated models.
* **Dynamic Templating Fixes**: Ensured `benchmarking.tpl.env` dynamically interpolates the proper target namespaces and service accounts instead of relying on hardcoded environment names.
## Motivation and Context
These utility improvements make the benchmarking suite significantly easier to use when testing new or custom models. By handling missing environment variables and missing model-specific directories natively, it removes manual boilerplate required from developers attempting to load-test their deployments.
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Tooling (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)