### PR TITLE
Fix DCGM 403 Error

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/inference-ref-arch_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/_shared_config/inference-ref-arch_variables.tf
@@ -69,8 +69,13 @@ locals {
 
   ira_inference_perf_ksa_project_roles_list                = ["roles/logging.viewer", "roles/monitoring.viewer", "roles/monitoring.metricsScopesViewer", "roles/storage.bucketViewer"]
   ira_inference_perf_bench_kubernetes_service_account_name = var.ira_inference_perf_bench_kubernetes_service_account_name != null ? var.ira_inference_perf_bench_kubernetes_service_account_name : "${local.unique_identifier_prefix}-inference-perf-bench"
-  hub_models_bucket_bench_results_name                     = var.hub_models_bucket_bench_results_name != null ? var.hub_models_bucket_bench_results_name : "${local.unique_identifier_prefix}-bench-results"
-  hub_models_bucket_bench_dataset_name                     = var.hub_models_bucket_bench_dataset_name != null ? var.hub_models_bucket_bench_dataset_name : "${local.unique_identifier_prefix}-bench-dataset"
+  # The llm-d-benchmark harness creates this KSA itself during run steps 0-6.
+  # The name is a fixed default in llm-d-benchmark
+  # (config/templates/values/defaults.yaml -> serviceAccount.name) and is NOT
+  # prefixed with local.unique_identifier_prefix, so it must be matched verbatim.
+  ira_llmd_benchmark_kubernetes_service_account_name = var.ira_llmd_benchmark_kubernetes_service_account_name != null ? var.ira_llmd_benchmark_kubernetes_service_account_name : "inference-perf-runner"
+  hub_models_bucket_bench_results_name               = var.hub_models_bucket_bench_results_name != null ? var.hub_models_bucket_bench_results_name : "${local.unique_identifier_prefix}-bench-results"
+  hub_models_bucket_bench_dataset_name               = var.hub_models_bucket_bench_dataset_name != null ? var.hub_models_bucket_bench_dataset_name : "${local.unique_identifier_prefix}-bench-dataset"
 
 }
 
@@ -288,6 +293,12 @@ variable "ira_online_tpu_vllm_image_url" {
 variable "ira_inference_perf_bench_kubernetes_service_account_name" {
   default     = null
   description = "The Kubernetes service account for the inference-perf benchmarking job."
+  type        = string
+}
+
+variable "ira_llmd_benchmark_kubernetes_service_account_name" {
+  default     = null
+  description = "The Kubernetes service account created by the llm-d-benchmark harness. Must match serviceAccount.name in the harness config; override only if that default is changed."
   type        = string
 }
 

--- a/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench/iam.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/terraform/inference_perf_bench/iam.tf
@@ -17,6 +17,9 @@ locals {
   ira_inference_perf_bench_online_gpu_ksa_member = "${local.cluster_wi_principal_prefix}/ns/${local.ira_online_gpu_kubernetes_namespace_name}/sa/${local.ira_inference_perf_bench_kubernetes_service_account_name}"
   ira_inference_perf_bench_online_tpu_ksa_member = "${local.cluster_wi_principal_prefix}/ns/${local.ira_online_tpu_kubernetes_namespace_name}/sa/${local.ira_inference_perf_bench_kubernetes_service_account_name}"
 
+  ira_llmd_benchmark_online_gpu_ksa_member = "${local.cluster_wi_principal_prefix}/ns/${local.ira_online_gpu_kubernetes_namespace_name}/sa/${local.ira_llmd_benchmark_kubernetes_service_account_name}"
+  ira_llmd_benchmark_online_tpu_ksa_member = "${local.cluster_wi_principal_prefix}/ns/${local.ira_online_tpu_kubernetes_namespace_name}/sa/${local.ira_llmd_benchmark_kubernetes_service_account_name}"
+
 }
 
 # --- GPU RESOURCES ---
@@ -39,6 +42,17 @@ resource "google_project_iam_member" "hub_models_ira_inference_perf_bench_online
   for_each = var.enable_gpu ? toset(local.ira_inference_perf_ksa_project_roles_list) : []
   project  = var.platform_default_project_id
   member   = local.ira_inference_perf_bench_online_gpu_ksa_member
+  role     = each.value
+}
+
+# The llm-d-benchmark telemetry-collector pod runs as this KSA and queries
+# monitoring.googleapis.com timeSeries for DCGM metrics. Without these roles the
+# collector receives HTTP 403 PERMISSION_DENIED and writes an error object into
+# dcgm_metrics.json instead of results.
+resource "google_project_iam_member" "hub_models_ira_llmd_benchmark_online_gpu_ksa_roles" {
+  for_each = var.enable_gpu ? toset(local.ira_inference_perf_ksa_project_roles_list) : []
+  project  = var.platform_default_project_id
+  member   = local.ira_llmd_benchmark_online_gpu_ksa_member
   role     = each.value
 }
 
@@ -70,6 +84,13 @@ resource "google_project_iam_member" "hub_models_ira_inference_perf_bench_online
   for_each = var.enable_tpu ? toset(local.ira_inference_perf_ksa_project_roles_list) : []
   project  = var.platform_default_project_id
   member   = local.ira_inference_perf_bench_online_tpu_ksa_member
+  role     = each.value
+}
+
+resource "google_project_iam_member" "hub_models_ira_llmd_benchmark_online_tpu_ksa_roles" {
+  for_each = var.enable_tpu ? toset(local.ira_inference_perf_ksa_project_roles_list) : []
+  project  = var.platform_default_project_id
+  member   = local.ira_llmd_benchmark_online_tpu_ksa_member
   role     = each.value
 }
 


### PR DESCRIPTION
## Grant monitoring.viewer to the llm-d-benchmark harness KSA

### Problem

GPU | TPU telemetry collection fails for every llm-d benchmark run. Instead of metrics,
`dcgm_metrics.json` contains:

```json
{
  "error": {
    "code": 403,
    "message": "Permission denied (or the resource may not exist).",
    "status": "PERMISSION_DENIED"
  }
} 
```
`skills/llm-d-benchmarking/scripts/helper-pods/telemetry-collector.yaml` runs as KSA inference-perf-runner and fetches a token from the GKE metadata server. Workload Identity is enabled cluster-wide and the KSA carries no iam.gke.io/gcp-service-account annotation, so the token belongs to the direct WI principal:
```
principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<PROJECT_ID>.svc.id.goog/subject/ns/<NAMESPACE>/sa/inference-perf-runner
```
That principal holds no IAM roles, so the call to monitoring.googleapis.com/v3/.../timeSeries
is denied.

This module already grants the correct role set - `local.ira_inference_perf_ksa_project_roles_list`
includes `roles/monitoring.viewer` - but binds it to `local.ira_inference_perf_bench_kubernetes_service_account_name`, which resolves to <prefix>-inference-perf-bench.

### Change

Bind the harness's own KSA, for both the GPU and TPU namespaces.