### PR TITLE
fix: update llmd router gateway chart 

### DIFF
--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-optimized-baseline_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-optimized-baseline_variables.tf
@@ -72,7 +72,7 @@ variable "llmd_ob_kubernetes_version_router_templates" {
 }
 
 variable "llmd_ob_router_chart" {
-  default     = "llm-d-router-gateway-dev"
+  default     = "llm-d-router-gateway"
   description = "Helm chart repo that holds llm charts"
   type        = string
 }
@@ -84,7 +84,7 @@ variable "llmd_ob_router_chart_repo" {
 }
 
 variable "llmd_ob_router_chart_version" {
-  default     = "v0"
+  default     = "v0.10.0"
   description = "Helm chart version for installing router"
   type        = string
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-optimized-baseline_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-optimized-baseline_variables.tf
@@ -84,7 +84,7 @@ variable "llmd_ob_router_chart_repo" {
 }
 
 variable "llmd_ob_router_chart_version" {
-  default     = "v0.10.0"
+  default     = "v0"
   description = "Helm chart version for installing router"
   type        = string
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-precise-prefix-cache-routing_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-precise-prefix-cache-routing_variables.tf
@@ -73,7 +73,7 @@ variable "llmd_ppcr_kubernetes_version_router_templates" {
 }
 
 variable "llmd_ppcr_router_chart" {
-  default     = "llm-d-router-gateway-dev"
+  default     = "llm-d-router-gateway"
   description = "Helm chart repo that holds llm charts"
   type        = string
 }
@@ -85,7 +85,7 @@ variable "llmd_ppcr_router_chart_repo" {
 }
 
 variable "llmd_ppcr_router_chart_version" {
-  default     = "v0"
+  default     = "v0.10.0"
   description = "Helm chart version for installing router"
   type        = string
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-precise-prefix-cache-routing_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-precise-prefix-cache-routing_variables.tf
@@ -85,7 +85,7 @@ variable "llmd_ppcr_router_chart_repo" {
 }
 
 variable "llmd_ppcr_router_chart_version" {
-  default     = "v0.10.0"
+  default     = "v0"
   description = "Helm chart version for installing router"
   type        = string
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-predicted-latency-routing_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-predicted-latency-routing_variables.tf
@@ -87,7 +87,7 @@ variable "llmd_plr_router_chart_repo" {
 }
 
 variable "llmd_plr_router_chart_version" {
-  default     = "v0.10.0"
+  default     = "v0"
   description = "Helm chart version for installing router"
   type        = string
 }

--- a/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-predicted-latency-routing_variables.tf
+++ b/platforms/gke/base/use-cases/inference-ref-arch/examples/llmd/_shared_config/llmd-predicted-latency-routing_variables.tf
@@ -75,7 +75,7 @@ variable "llmd_plr_kubernetes_version_router_templates" {
 }
 
 variable "llmd_plr_router_chart" {
-  default     = "llm-d-router-gateway-dev"
+  default     = "llm-d-router-gateway"
   description = "Helm chart repo that holds llm charts"
   type        = string
 }
@@ -87,7 +87,7 @@ variable "llmd_plr_router_chart_repo" {
 }
 
 variable "llmd_plr_router_chart_version" {
-  default     = "v0"
+  default     = "v0.10.0"
   description = "Helm chart version for installing router"
   type        = string
 }


### PR DESCRIPTION
Updates the helm chart from the dev version to the public gateway release `v0` to fix deployment 403 errors re: https://github.com/llm-d/llm-d-router/pkgs/container/charts%2Fllm-d-router-gateway