### PR TITLE
fix: do not abort run_benchmark.sh on the tuner prompt without a TTY

### DIFF
--- a/skills/llm-d-benchmarking/scripts/run_benchmark.sh
+++ b/skills/llm-d-benchmarking/scripts/run_benchmark.sh
@@ -96,7 +96,13 @@ validate_workload_config() {
   [ ! -f "$f" ] && return 0
   set +e; python3 "${REPO_DIR}/skills/llm-d-workload-tuner/scripts/tune_workload.py" --perf-yaml "$f" --accelerator-type "$ACCELERATOR_TYPE" --spec "$SPEC" --model "$MODEL_NAME"; code=$?; set -e
   if [ $code -eq 2 ]; then
-    read -p "There are gaps between the benchmark workload profile and the current vLLM config detected. Do you want to apply the tuned configuration? (y/N): " confirm
+    local confirm=""
+    if [ -t 0 ]; then
+      # `read` returns non-zero on EOF, which would abort the script under `set -e`.
+      read -p "There are gaps between the benchmark workload profile and the current vLLM config detected. Do you want to apply the tuned configuration? (y/N): " confirm || confirm=""
+    else
+      echo "Non-interactive shell detected; not prompting to apply the tuned configuration."
+    fi
     if [[ "$confirm" =~ ^[Yy]$ ]]; then
       echo "Applying tuned configuration updates to the manifests..."
       python3 "${REPO_DIR}/skills/llm-d-workload-tuner/scripts/tune_workload.py" --perf-yaml "$f" --accelerator-type "$ACCELERATOR_TYPE" --spec "$SPEC" --model "$MODEL_NAME" --apply


### PR DESCRIPTION
## Problem

`validate_workload_config` in `skills/llm-d-benchmarking/scripts/run_benchmark.sh` prompts with `read -p` when `tune_workload.py` exits `2` (sizing gaps found).

`read` returns non-zero at EOF, and `set -e` is restored on the line immediately before the prompt, so that non-zero status **aborts the entire script**:

```console
$ ./run_benchmark.sh agentic_code_generation.yaml http://<gw> <ns> google/gemma-4-31b-it < /dev/null
Endpoint preflight OK: http://<gw>/v1/models -> HTTP 200
...
TENSOR_PARALLEL_SIZE: curr=8, req=8
MAX_MODEL_LEN: curr=65536, req=21024
GPU_MEMORY_UTILIZATION: curr=0.95, req=0.95
$ echo $?
1
```

The run dies before any benchmark work starts and prints no error explaining why. This affects every context where stdin is not a terminal — CI, `nohup`/background jobs, and agent-driven runs.

It is easy to hit: the prompt fires whenever *any* knob differs from the tuner's suggestion, so a correctly sized deployment still aborts. In the run above the deployment was already adequate (`MAX_MODEL_LEN` 65536 ≥ the required 21024, TP and memory utilization both matching) — the only gap was a suggested extra vLLM arg.

## Fix

Prompt only when stdin is a TTY, and guard `read` so EOF cannot abort the script.

Non-interactive runs now proceed with the current configuration, which is exactly what the existing "answer N" branch already does — so behaviour for interactive users is unchanged.

## Testing

- `bash -n skills/llm-d-benchmarking/scripts/run_benchmark.sh` passes.
- Re-ran the same command with stdin redirected from `/dev/null`; the script now continues past the tuner into the harness phases instead of exiting 1.
- Interactive behaviour verified unchanged: the prompt still appears from a terminal, `y` applies the tuned config, anything else proceeds.